### PR TITLE
Add OpenUI creator program article drafts

### DIFF
--- a/Articles/From Static Dashboards to Living Interfaces.md
+++ b/Articles/From Static Dashboards to Living Interfaces.md
@@ -1,0 +1,285 @@
+# From Static Dashboards to Living Interfaces: How AI Is Redefining the Way We Display Data
+
+Dashboards are usually built like answers to questions that have already been asked.
+
+That made sense when the expensive part of analytics was getting any useful view onto the screen. A team would agree on a few key metrics, a designer or analyst would arrange charts around them, and the dashboard would become the shared place everyone checked before a meeting.
+
+The problem is that real work rarely stays inside that fixed layout.
+
+A support lead wants to see churn risk by ticket category, but only for enterprise accounts with open escalations. A sales manager wants pipeline slippage, but grouped by deal age and next action rather than by stage. A finance analyst wants the same revenue table as last week, except this time the interesting thing is not total revenue. It is the weird spike in refunds in one region after a pricing change.
+
+Traditional dashboards are good at showing a stable operating picture. They are much worse at adapting to the question the user is actually asking right now.
+
+That gap is where generative UI becomes interesting. Not because it makes dashboards prettier, and not because every chart should be rebuilt by a model on every request. The useful shift is smaller and more practical: an AI system can use the user's intent, the available data, and a constrained component library to assemble an interface for the current task instead of forcing every task through the same fixed set of panels.
+
+In other words, the dashboard stops being a static page and starts becoming a living interface.
+
+## The Static Dashboard Problem
+
+Most dashboard failures are not failures of visualization. They are failures of fit.
+
+The charts may be accurate. The data model may be clean. The page may even be fast. But the interface still encodes assumptions made at design time:
+
+- Which metrics matter most
+- Which filters users will need
+- Which dimensions should be grouped together
+- Which comparison is worth highlighting
+- Which level of detail is appropriate
+
+Those assumptions age quickly. Teams change priorities, product surfaces change, customer behavior changes, and dashboards collect tabs, filters, secondary pages, and one-off exports. Eventually the dashboard becomes a compromise: broad enough to cover many workflows, but specific enough to fully serve none of them.
+
+The common escape hatch is natural language querying. The user asks, "Why did activation drop last week?" and the system returns a text explanation. That helps, but it often throws away the thing dashboards are good at: visual comparison, scanning, interaction, and drill-down.
+
+For many analytical tasks, prose is the wrong final artifact. The user does not only need an answer. They need a small working surface:
+
+- A table they can sort
+- A chart they can inspect
+- A comparison card they can scan
+- A form that captures the next decision
+- A set of alerts that link to source rows
+
+Text can describe that surface. A living interface can render it.
+
+## What A Living Interface Actually Is
+
+A living interface is not a dashboard with a chatbot bolted onto the corner.
+
+It is an interface that can be composed at runtime from safe, known building blocks. The model does not get permission to emit arbitrary HTML. It gets a vocabulary: `MetricCard`, `LineChart`, `DataTable`, `Alert`, `ComparisonGrid`, `ActionButton`, or whatever components the product team has chosen to expose.
+
+The system prompt tells the model what components exist and what props they accept. The user asks a question. The model selects and configures a component tree. The renderer turns that structured output into real UI.
+
+OpenUI is one implementation of this pattern. Its core idea is OpenUI Lang, a compact, streaming-first language for model-generated interfaces. The OpenUI repository describes the flow as component library -> system prompt -> LLM -> OpenUI Lang stream -> renderer -> live UI. That framing matters because it keeps generation constrained by components rather than letting the model improvise an entire frontend.
+
+The practical result is that an AI answer can become a product surface:
+
+User:
+
+> Which regions are underperforming this quarter, and what should I look at first?
+
+Static dashboard:
+
+The user opens the regional performance dashboard, changes the date range, scans a bar chart, opens a table, adds a filter, exports CSV, and asks a follow-up.
+
+Text-only assistant:
+
+The assistant replies with a paragraph: "West and Central are underperforming, with West down 14 percent quarter over quarter..."
+
+Living interface:
+
+The assistant renders:
+
+- A ranked table of regions by variance
+- A sparkline for each region
+- A highlighted anomaly card for refunds, churn, or conversion
+- Suggested follow-up buttons like "show by segment" or "compare to last pricing change"
+
+The difference is not visual polish. It is task fit.
+
+## The Spectrum Between Static And Generative
+
+It helps to avoid treating dashboards as either old or new. Most products will sit somewhere along a spectrum.
+
+At one end are fixed reports. They are reliable, reproducible, and easy to audit. A board reporting package, compliance dashboard, billing ledger, or system health page often belongs here. The same view should mean the same thing every time.
+
+Next come configurable dashboards. Users can change filters, date ranges, breakdowns, and saved views. This is where most BI tools live. It gives users control, but it also shifts the burden of exploration onto them.
+
+Then come AI-assisted dashboards. The layout is still mostly static, but the system suggests filters, explains anomalies, writes summaries, or recommends next views.
+
+Finally, there are generative interfaces. The model can assemble the view itself from approved components. The user asks a question, and the interface changes shape to match the job.
+
+The last category is powerful, but it should not replace the others everywhere. The strongest products will mix them:
+
+- Fixed dashboards for canonical metrics
+- Configurable dashboards for repeat workflows
+- Generative interfaces for ad hoc investigation and task-specific views
+
+The useful question is not "Should AI generate every dashboard?" It is "Where are users currently contorting a static dashboard into a task-specific interface?"
+
+## Why Generative UI Changes The Dashboard Backlog
+
+Every analytics-heavy product has a hidden dashboard backlog.
+
+It might not be tracked in Jira. It shows up as Slack messages:
+
+- "Can we add a filter for plan type?"
+- "Can this chart split by region?"
+- "Can we get this table but for failed renewals?"
+- "Can you make a version for the exec review?"
+- "Can we add one more column?"
+
+These requests are often legitimate. They also do not always justify permanent UI. A user may need a view for one investigation, one meeting, or one customer escalation. Building every temporary view into the product creates clutter.
+
+Generative UI offers a middle path. Instead of shipping every possible view, the team ships a component library and data access layer. The model composes temporary, contextual views from those primitives.
+
+For example, a product analytics app might expose:
+
+```ts
+const analyticsComponents = [
+  MetricCard,
+  TimeSeriesChart,
+  SegmentBreakdown,
+  FunnelTable,
+  AnomalyCallout,
+  FollowupActions,
+]
+```
+
+The model is not asked to invent charting code. It is asked to choose among product-approved components:
+
+```text
+If the user asks for a trend, prefer TimeSeriesChart.
+If the user asks for "why", combine AnomalyCallout with SegmentBreakdown.
+If the user needs to act, include FollowupActions with concrete next steps.
+```
+
+That changes the economics of dashboard work. Engineers still build the primitives. Designers still define visual language. Analysts still define trusted metrics. But many one-off layout decisions move from a ticket queue into runtime composition.
+
+## A Concrete Example: Support Operations
+
+Imagine a support operations dashboard. The static version has:
+
+- Tickets by status
+- First response time
+- Average resolution time
+- CSAT
+- Escalation count
+- Top tags
+
+That is useful. It is also generic.
+
+Now a support lead asks:
+
+> Show me why enterprise escalations increased this week.
+
+A living interface could render a task-specific view:
+
+```text
+<Dashboard title="Enterprise escalation drivers">
+  <MetricCard label="Escalations" value="47" delta="+31%" tone="warning" />
+  <MetricCard label="Median time to first human reply" value="3h 12m" delta="+42%" />
+  <LineChart title="Escalations by day" series="enterpriseEscalations" />
+  <DataTable
+    title="Top contributing tags"
+    columns=["tag", "tickets", "change", "median_age", "owner"]
+    rows="topEscalationTags"
+  />
+  <Alert
+    title="Likely driver"
+    body="Billing and SSO tickets account for 68% of the increase. Both show delayed first human response after the routing rule change on Monday."
+  />
+  <ActionList actions=["Open routing rule audit", "Compare with SMB tickets", "Draft escalation summary"] />
+</Dashboard>
+```
+
+That is not the same as a chatbot saying the answer aloud or writing it in prose. It gives the user a compact workspace: overview, evidence, likely cause, and next actions.
+
+The static dashboard remains useful for daily monitoring. The generated view is useful for investigation.
+
+## Streaming Matters More Than It Sounds
+
+One reason OpenUI's streaming-first design matters is that generated interfaces should not feel like reports that appear after a long blank pause.
+
+OpenUI Lang is designed so model output can be parsed and rendered progressively as tokens arrive. The OpenUI README describes a streaming renderer that updates the UI as output arrives, and its benchmark section reports that OpenUI Lang is substantially more token-efficient than JSON-based formats across several UI scenarios.
+
+That has two product implications.
+
+First, users get feedback earlier. A heading, summary card, or skeleton can appear while the rest of the table or chart is still being generated. For analytical workflows, perceived progress matters. A blank screen makes the user wonder whether the agent is stuck.
+
+Second, the UI can stay interactive as it grows. In the Thesys voice-agent reference implementation, the agent streams generated visual UI over a LiveKit text stream with the topic `genui`, and the frontend registers a handler for that stream. As content arrives, the React UI passes the accumulated response into a `C1Component`. That is the same mental model a dashboard product needs: generated structure should appear incrementally, not as a final blob.
+
+In a data product, that might look like:
+
+1. Render the question restatement and primary KPI cards.
+2. Stream in the anomaly explanation.
+3. Add the table once the query result arrives.
+4. Add follow-up actions after the model sees the evidence.
+
+The interface becomes a live conversation between data, model, and user.
+
+## The Hard Parts
+
+Living interfaces are not magic. They move complexity around.
+
+Data correctness becomes the first hard problem. A generated chart is only useful if it is grounded in trusted queries. The model should not be calculating revenue from raw rows in free-form text. It should call a tool or API that returns typed, verified results, then choose how to present them.
+
+Component constraints are the second hard problem. The more freedom the model has, the more inconsistent the product becomes. A good generative UI system should expose a curated component library, not an open-ended canvas. Designers still own the design system. The model composes within it.
+
+Reproducibility is the third hard problem. Some dashboards must be stable because users need to compare the same view over time. A generated interface can still log the prompt, data snapshot, component tree, and model version, but that requires deliberate instrumentation.
+
+Latency is the fourth hard problem. A static dashboard can precompute and cache aggressively. A living interface may need to retrieve data, ask the model to plan a view, stream UI, and handle follow-up actions. The product needs a latency budget:
+
+- Which data queries must finish before rendering starts?
+- Which parts can stream later?
+- Which generated views should be cached?
+- When should the system fall back to a static chart or text summary?
+
+Finally, there is trust. If users cannot tell where a number came from, they will not use the interface for serious work. Generated dashboards need source links, query provenance, timestamps, and visible assumptions.
+
+## When Static Dashboards Are Still Better
+
+Static dashboards are not going away. They are the right tool when:
+
+- The view is a shared organizational source of truth.
+- The same metric needs to be reviewed repeatedly.
+- Auditability matters more than personalization.
+- The task is monitoring rather than exploration.
+- The cost of a wrong layout is high.
+
+A finance close dashboard, an uptime page, a compliance report, or a board KPI deck should not reshape itself casually.
+
+The living interface belongs next to those surfaces, not necessarily instead of them. Think of it as the exploratory layer: a way to ask new questions without waiting for the dashboard backlog to catch up.
+
+## What Teams Should Build First
+
+The best first use case is not "replace our BI tool with AI." That is too broad.
+
+Start with one workflow where users already ask for custom views:
+
+- Support escalation analysis
+- Sales pipeline inspection
+- Product funnel debugging
+- Marketing campaign comparison
+- Usage analytics for customer success
+- Incident postmortem exploration
+
+Then define a narrow component set:
+
+- One or two metric cards
+- One table
+- One time-series chart
+- One breakdown chart
+- One callout component
+- One action list
+
+Add a tool layer that returns trusted data. Give the model the component contracts. Log the generated component tree. Let users give feedback on whether the generated view answered their question.
+
+Measure the result like a product feature:
+
+- Did users complete the task without exporting data?
+- Did they ask fewer follow-up questions in Slack?
+- Did time-to-insight fall?
+- Which generated components were used most often?
+- Which prompts produced confusing layouts?
+
+If those numbers move, expand the component vocabulary.
+
+## The Interface Is Becoming The Answer
+
+The old dashboard model assumed that teams could predict the right set of views in advance. Sometimes they can. Often they cannot.
+
+Generative UI changes that assumption. The product team can define safe building blocks, data boundaries, and design rules, then let the interface assemble itself around the user's current question.
+
+That is the real shift from static dashboards to living interfaces. Not dashboards that wiggle. Not charts with AI summaries pasted underneath. A working surface that appears at the moment of need, shaped by the task, grounded in real data, and constrained enough to be trusted.
+
+For developers, the opportunity is not to make every interface unpredictable. It is to stop hardcoding temporary analytical views as permanent product surfaces.
+
+The dashboard of the future is not one page with more filters.
+
+It is a system that knows when to show the stable view, when to generate the task-specific view, and how to keep both connected to the same source of truth.
+
+## References
+
+- OpenUI repository: https://github.com/thesysdev/openui
+- OpenUI documentation and playground: https://www.openui.com/
+- Thesys voice-agent generative UI demo: https://github.com/thesysdev/voice-agent-generativeui
+- LiveKit Agents documentation: https://docs.livekit.io/agents/

--- a/Articles/OpenUI for Voice Agents Pairing LiveKit with Generative UI.md
+++ b/Articles/OpenUI for Voice Agents Pairing LiveKit with Generative UI.md
@@ -1,0 +1,327 @@
+# OpenUI for Voice Agents: Pairing LiveKit with Generative UI for Real-Time Visual Feedback
+
+Voice agents are becoming good enough that the bottleneck is no longer only speech quality.
+
+The harder problem is memory. Audio disappears as soon as it is spoken. If an agent compares three pricing plans, summarizes an incident, or walks through a product search, the user has to hold the important details in their head while the conversation keeps moving.
+
+That is fine for simple answers. It breaks down for structured work.
+
+A useful voice agent should be able to speak and show. When the answer contains a comparison, it should render a table. When the answer contains steps, it should render a checklist. When the answer contains candidates, it should render cards. When the user needs to choose, it should render actions that can continue the conversation.
+
+This is where LiveKit and OpenUI fit naturally together. LiveKit gives you the real-time audio session, agent lifecycle, and room transport. OpenUI gives the model a constrained way to produce interactive UI instead of plain text. Together, they let a voice agent talk while a visual surface streams onto the screen.
+
+This article walks through that pattern using the Thesys voice-agent generative UI demo as the reference architecture.
+
+## The Product Problem
+
+Most voice agents still treat the screen as secondary. The agent speaks, the transcript scrolls, and maybe a few status indicators show that the system is listening or thinking.
+
+That design wastes a useful channel.
+
+Consider a voice agent for travel planning. A user asks:
+
+> Compare three hotels near the conference venue and show me which one is best for walking distance, price, and cancellation policy.
+
+A voice-only response has to serialize everything:
+
+- Hotel A is cheaper, but farther away
+- Hotel B is closest, but has a strict cancellation policy
+- Hotel C is more expensive, but includes breakfast and flexible cancellation
+
+The user hears the first option, then the second, then the third, and then asks the agent to repeat the first one. The agent is not necessarily wrong. The interface is wrong for the task.
+
+The same happens in support workflows, analytics, scheduling, onboarding, and product comparison. Once the answer has structure, speech alone becomes a narrow output format.
+
+The goal is not to replace voice with UI. The goal is to make voice and UI cooperate:
+
+- Voice explains what is happening
+- UI preserves the structure
+- Actions let the user continue without restating intent
+
+## The Architecture At A Glance
+
+The demo is split into two parts:
+
+- A LiveKit agent that listens, reasons, calls tools, and streams generated UI
+- A Next.js frontend that connects to the room, receives the UI stream, and renders it with the Thesys GenUI SDK
+
+The important idea is that generated UI is not returned as a normal chat message. It travels over a dedicated LiveKit text stream topic.
+
+The flow looks like this:
+
+1. The user speaks to the voice agent.
+2. The agent decides that the answer needs a visual surface.
+3. The agent calls a `show_ui` tool with structured content.
+4. The tool sends that content to the Thesys embed API.
+5. The generated OpenUI response streams back chunk by chunk.
+6. The tool writes those chunks to a LiveKit text stream with the topic `genui`.
+7. The frontend listens for `genui`, accumulates the stream, and renders it with `C1Component`.
+8. The voice agent returns immediately so it can keep speaking while the interface appears.
+
+That last part matters. The UI stream is started in the background. The voice LLM does not wait for a full interface payload before responding. The experience feels like a multimodal conversation instead of a turn-based form generator.
+
+## The Agent Side: A Tool That Streams UI
+
+The core server-side piece is the `ShowUITool` in the demo agent.
+
+Conceptually, it does three jobs:
+
+- Defines when the agent should use visual UI
+- Converts the agent's structured content into an OpenUI stream
+- Publishes that stream into the LiveKit room
+
+The tool description is intentionally direct. It tells the voice model to call the tool for comparisons, lists, structured data, cards, and similar visual output. The input is a single `content` string, but that string should be complete and specific enough for the UI model to build a useful surface.
+
+Here is the shape of the tool:
+
+```ts
+return llm.tool({
+  description:
+    "Display rich visual UI to the user. Pass the COMPLETE structured content you want to visualize.",
+  parameters: z.object({
+    content: z.string().describe(
+      "The full structured content to display visually. Be detailed and specific.",
+    ),
+  }),
+  execute: async ({ content }) => {
+    // Start UI streaming work here.
+    return "UI is loading on screen. Tell the user in 1-2 natural sentences what you are showing them.";
+  },
+});
+```
+
+The interesting part is inside `execute`.
+
+First, the tool cancels any previous in-flight UI stream:
+
+```ts
+this.abortController?.abort();
+this.abortController = new AbortController();
+const { signal } = this.abortController;
+```
+
+That is a practical detail, but an important one. In a real conversation, users interrupt, clarify, and change direction. If the agent is still streaming an old comparison table while the user asks a new question, the screen becomes misleading. Canceling the previous stream keeps the visible UI aligned with the current turn.
+
+Then the tool opens a LiveKit text stream:
+
+```ts
+writer = await this.room.localParticipant.streamText({
+  topic: "genui",
+});
+```
+
+The topic name is the contract between the agent and frontend. Audio can continue over the normal LiveKit media path while UI chunks travel over this named text stream.
+
+Next, the tool calls the Thesys embed API using an OpenAI-compatible client:
+
+```ts
+const stream = await this.thesysClient.chat.completions.create(
+  {
+    model: THESYS_MODEL,
+    messages: [
+      { role: "system", content: THESYS_SYSTEM_PROMPT },
+      { role: "user", content },
+    ],
+    stream: true,
+  },
+  { signal },
+);
+```
+
+The system prompt is short but specific: the UI model is being used alongside a voice agent, and its job is to turn the voice agent's content into a visually appealing interactive component.
+
+Finally, each streamed delta is written into the LiveKit room:
+
+```ts
+for await (const chunk of stream) {
+  if (signal.aborted) break;
+  const delta = chunk.choices[0]?.delta?.content;
+  if (delta) {
+    await writer.write(delta);
+  }
+}
+
+await writer.close();
+```
+
+The tool returns immediately after starting this background work. That design keeps the spoken response responsive while the visual response renders progressively.
+
+## The Frontend Side: Listen For `genui`
+
+On the frontend, the generated UI stream is handled inside the main voice UI component.
+
+The important state is small:
+
+```ts
+const [genUIContent, setGenUIContent] = useState("");
+const [isStreaming, setIsStreaming] = useState(false);
+```
+
+When the LiveKit room is available, the frontend registers a text stream handler for the same `genui` topic used by the agent:
+
+```ts
+room.registerTextStreamHandler("genui", handleGenUI);
+```
+
+The handler accumulates chunks as they arrive:
+
+```ts
+const handleGenUI = (reader: AsyncIterable<string>) => {
+  setIsStreaming(true);
+  setGenUIContent("");
+  let acc = "";
+
+  (async () => {
+    try {
+      for await (const chunk of reader) {
+        acc += chunk;
+        setGenUIContent(acc);
+      }
+    } finally {
+      setIsStreaming(false);
+    }
+  })();
+};
+```
+
+That accumulated string becomes the input to the renderer:
+
+```tsx
+<GenUIPanel
+  content={genUIContent}
+  isStreaming={isStreaming}
+  isProcessingAction={isProcessingAction}
+  isAgentReady={isAgentReady}
+  onAction={handleAction}
+/>
+```
+
+Inside the panel, the actual rendering is handled by the Thesys component:
+
+```tsx
+<C1Component
+  c1Response={content}
+  isStreaming={isStreaming}
+  onAction={onAction}
+/>
+```
+
+This keeps the application boundary clean. The LiveKit component manages connection state, audio session lifecycle, transcript state, and incoming UI streams. The GenUI panel renders the model-generated interface.
+
+## Actions Close The Loop
+
+Generated UI becomes much more useful when it can continue the conversation.
+
+In the demo, UI actions are sent back into the chat path. If the generated component emits an action like `continue_conversation`, the frontend extracts an `llmFriendlyMessage` and sends it as a chat message:
+
+```ts
+const message = event.params?.llmFriendlyMessage as string | undefined;
+if (message) {
+  setIsProcessingAction(true);
+  sendChatMessage(message);
+}
+```
+
+That means a generated comparison table can include actions such as:
+
+- "Compare only flexible cancellation"
+- "Show the cheapest option"
+- "Explain the tradeoff"
+- "Book this one"
+
+The user can click instead of restating a long instruction by voice. The agent receives a clean follow-up message and can continue the same loop: speak, call tools, stream UI, accept actions.
+
+This is the difference between showing a decorative card and building a multimodal agent interface.
+
+## Choosing Between Pipeline And Realtime Agents
+
+The demo supports two agent modes.
+
+In pipeline mode, the agent is built from separate speech-to-text, language model, text-to-speech, and voice activity detection pieces. In realtime mode, it uses OpenAI's realtime model path.
+
+That choice changes the audio stack, but not the UI pattern. The `show_ui` tool remains the bridge between agent reasoning and visual rendering.
+
+For product teams, that separation is useful. You can change voice infrastructure, model providers, or speech settings while keeping the UI stream contract stable:
+
+- The backend publishes generated UI chunks on `genui`
+- The frontend listens on `genui`
+- The renderer turns the accumulated stream into interface
+
+That small contract makes the architecture easier to reason about.
+
+## What To Show Visually
+
+Not every answer needs generated UI.
+
+A good rule of thumb: call `show_ui` when the answer contains structure the user may need to inspect, compare, remember, or act on.
+
+Strong candidates:
+
+- Product comparisons
+- Search results
+- Itineraries
+- Pricing breakdowns
+- Support ticket summaries
+- Data snapshots
+- Forms and confirmation steps
+- Step-by-step troubleshooting
+
+Weak candidates:
+
+- Short factual answers
+- Conversational acknowledgements
+- Simple yes/no confirmations
+- Sensitive data that should stay out of persistent UI
+- Anything where the model lacks trusted source data
+
+The best voice agents will not generate UI constantly. They will generate it at the moments when the screen makes the conversation easier to understand.
+
+## Practical Guardrails
+
+Pairing voice with generated UI introduces a few product and engineering concerns.
+
+First, keep the data source trustworthy. The `show_ui` tool should visualize content the agent already has permission to show. If the UI depends on external data, fetch that data through tools with clear permissions and then pass the result into the UI generation step.
+
+Second, cancel stale streams. The demo's abort controller is a good pattern. Voice interactions are interruptible by nature, so old visual output should not keep arriving after the conversation has moved on.
+
+Third, make loading state visible. Streaming UI is powerful because the user sees progress. The frontend should distinguish between empty, loading, streaming, complete, and action-processing states.
+
+Fourth, preserve transcript and UI together. The transcript explains why a surface appeared. The surface preserves the structured result. Users need both when they look back at a conversation.
+
+Fifth, log generated UI payloads. In production, you will want to inspect which prompts create useful interfaces, which ones confuse users, and which actions drive follow-up turns.
+
+## A Minimal Build Plan
+
+If you are adding generative UI to an existing LiveKit voice agent, start small.
+
+1. Add a `show_ui` tool to the agent.
+2. Give it one clear input: complete structured content to visualize.
+3. Inside the tool, call the OpenUI or Thesys generation endpoint with streaming enabled.
+4. Publish each streamed chunk into the LiveKit room on a dedicated text topic.
+5. In the frontend, register a text stream handler for that topic.
+6. Accumulate the stream in state.
+7. Render it with a GenUI component.
+8. Wire UI actions back into the agent as chat messages.
+
+You do not need to rebuild the whole voice experience at once. Pick one workflow where speech is obviously too linear: comparing options, summarizing a case, filling a form, or showing ranked results.
+
+Once that works, measure whether users ask fewer repeat questions and complete the workflow faster.
+
+## Why This Pattern Matters
+
+Voice agents make software feel more direct. Generative UI makes AI output more usable. The combination is stronger than either part alone.
+
+A voice-only agent can be fast but hard to inspect. A UI-only agent can be rich but slow to navigate. A multimodal agent can explain the answer aloud while showing the structure visually and letting the user act without breaking the flow.
+
+LiveKit provides the real-time room and agent infrastructure. OpenUI provides the generated interface layer. The bridge between them can be as small as a streamed text topic and a rendering component.
+
+That is the practical takeaway: multimodal agents do not require a completely new application architecture. They require a clear contract between speech, tools, generated UI, and user actions.
+
+When that contract is in place, the voice agent stops being a talking transcript and starts becoming a real working surface.
+
+## References
+
+- OpenUI repository: https://github.com/thesysdev/openui
+- OpenUI documentation and playground: https://www.openui.com/
+- Thesys voice-agent generative UI demo: https://github.com/thesysdev/voice-agent-generativeui
+- LiveKit Agents documentation: https://docs.livekit.io/agents/


### PR DESCRIPTION
## Summary

Adds two written-content drafts for open OpenUI Creator Program bounty topics:

- #8: From Static Dashboards to Living Interfaces: How AI Is Redefining the Way We Display Data
- #6: OpenUI for Voice Agents: Pairing LiveKit with Generative UI for Real-Time Visual Feedback

## Notes

I am opening this as a draft because the program asks creators to comment and get assigned before final submission. Both drafts are complete Markdown articles and can be split or revised depending on which topic the maintainers want to assign/review first.

## Validation

- Ran `git diff --check`
- Grounded the voice-agent article in the Thesys `voice-agent-generativeui` reference implementation, including the `show_ui` tool, the `genui` LiveKit text stream topic, and frontend rendering through `C1Component`.