### PR TITLE
Add article on living dashboard interfaces

### DIFF
--- a/Articles/From Static Dashboards to Living Interfaces.md
+++ b/Articles/From Static Dashboards to Living Interfaces.md
@@ -1,0 +1,285 @@
+# From Static Dashboards to Living Interfaces: How AI Is Redefining the Way We Display Data
+
+Dashboards are usually built like answers to questions that have already been asked.
+
+That made sense when the expensive part of analytics was getting any useful view onto the screen. A team would agree on a few key metrics, a designer or analyst would arrange charts around them, and the dashboard would become the shared place everyone checked before a meeting.
+
+The problem is that real work rarely stays inside that fixed layout.
+
+A support lead wants to see churn risk by ticket category, but only for enterprise accounts with open escalations. A sales manager wants pipeline slippage, but grouped by deal age and next action rather than by stage. A finance analyst wants the same revenue table as last week, except this time the interesting thing is not total revenue. It is the weird spike in refunds in one region after a pricing change.
+
+Traditional dashboards are good at showing a stable operating picture. They are much worse at adapting to the question the user is actually asking right now.
+
+That gap is where generative UI becomes interesting. Not because it makes dashboards prettier, and not because every chart should be rebuilt by a model on every request. The useful shift is smaller and more practical: an AI system can use the user's intent, the available data, and a constrained component library to assemble an interface for the current task instead of forcing every task through the same fixed set of panels.
+
+In other words, the dashboard stops being a static page and starts becoming a living interface.
+
+## The Static Dashboard Problem
+
+Most dashboard failures are not failures of visualization. They are failures of fit.
+
+The charts may be accurate. The data model may be clean. The page may even be fast. But the interface still encodes assumptions made at design time:
+
+- Which metrics matter most
+- Which filters users will need
+- Which dimensions should be grouped together
+- Which comparison is worth highlighting
+- Which level of detail is appropriate
+
+Those assumptions age quickly. Teams change priorities, product surfaces change, customer behavior changes, and dashboards collect tabs, filters, secondary pages, and one-off exports. Eventually the dashboard becomes a compromise: broad enough to cover many workflows, but specific enough to fully serve none of them.
+
+The common escape hatch is natural language querying. The user asks, "Why did activation drop last week?" and the system returns a text explanation. That helps, but it often throws away the thing dashboards are good at: visual comparison, scanning, interaction, and drill-down.
+
+For many analytical tasks, prose is the wrong final artifact. The user does not only need an answer. They need a small working surface:
+
+- A table they can sort
+- A chart they can inspect
+- A comparison card they can scan
+- A form that captures the next decision
+- A set of alerts that link to source rows
+
+Text can describe that surface. A living interface can render it.
+
+## What A Living Interface Actually Is
+
+A living interface is not a dashboard with a chatbot bolted onto the corner.
+
+It is an interface that can be composed at runtime from safe, known building blocks. The model does not get permission to emit arbitrary HTML. It gets a vocabulary: `MetricCard`, `LineChart`, `DataTable`, `Alert`, `ComparisonGrid`, `ActionButton`, or whatever components the product team has chosen to expose.
+
+The system prompt tells the model what components exist and what props they accept. The user asks a question. The model selects and configures a component tree. The renderer turns that structured output into real UI.
+
+OpenUI is one implementation of this pattern. Its core idea is OpenUI Lang, a compact, streaming-first language for model-generated interfaces. The OpenUI repository describes the flow as component library -> system prompt -> LLM -> OpenUI Lang stream -> renderer -> live UI. That framing matters because it keeps generation constrained by components rather than letting the model improvise an entire frontend.
+
+The practical result is that an AI answer can become a product surface:
+
+User:
+
+> Which regions are underperforming this quarter, and what should I look at first?
+
+Static dashboard:
+
+The user opens the regional performance dashboard, changes the date range, scans a bar chart, opens a table, adds a filter, exports CSV, and asks a follow-up.
+
+Text-only assistant:
+
+The assistant replies with a paragraph: "West and Central are underperforming, with West down 14 percent quarter over quarter..."
+
+Living interface:
+
+The assistant renders:
+
+- A ranked table of regions by variance
+- A sparkline for each region
+- A highlighted anomaly card for refunds, churn, or conversion
+- Suggested follow-up buttons like "show by segment" or "compare to last pricing change"
+
+The difference is not visual polish. It is task fit.
+
+## The Spectrum Between Static And Generative
+
+It helps to avoid treating dashboards as either old or new. Most products will sit somewhere along a spectrum.
+
+At one end are fixed reports. They are reliable, reproducible, and easy to audit. A board reporting package, compliance dashboard, billing ledger, or system health page often belongs here. The same view should mean the same thing every time.
+
+Next come configurable dashboards. Users can change filters, date ranges, breakdowns, and saved views. This is where most BI tools live. It gives users control, but it also shifts the burden of exploration onto them.
+
+Then come AI-assisted dashboards. The layout is still mostly static, but the system suggests filters, explains anomalies, writes summaries, or recommends next views.
+
+Finally, there are generative interfaces. The model can assemble the view itself from approved components. The user asks a question, and the interface changes shape to match the job.
+
+The last category is powerful, but it should not replace the others everywhere. The strongest products will mix them:
+
+- Fixed dashboards for canonical metrics
+- Configurable dashboards for repeat workflows
+- Generative interfaces for ad hoc investigation and task-specific views
+
+The useful question is not "Should AI generate every dashboard?" It is "Where are users currently contorting a static dashboard into a task-specific interface?"
+
+## Why Generative UI Changes The Dashboard Backlog
+
+Every analytics-heavy product has a hidden dashboard backlog.
+
+It might not be tracked in Jira. It shows up as Slack messages:
+
+- "Can we add a filter for plan type?"
+- "Can this chart split by region?"
+- "Can we get this table but for failed renewals?"
+- "Can you make a version for the exec review?"
+- "Can we add one more column?"
+
+These requests are often legitimate. They also do not always justify permanent UI. A user may need a view for one investigation, one meeting, or one customer escalation. Building every temporary view into the product creates clutter.
+
+Generative UI offers a middle path. Instead of shipping every possible view, the team ships a component library and data access layer. The model composes temporary, contextual views from those primitives.
+
+For example, a product analytics app might expose:
+
+```ts
+const analyticsComponents = [
+  MetricCard,
+  TimeSeriesChart,
+  SegmentBreakdown,
+  FunnelTable,
+  AnomalyCallout,
+  FollowupActions,
+]
+```
+
+The model is not asked to invent charting code. It is asked to choose among product-approved components:
+
+```text
+If the user asks for a trend, prefer TimeSeriesChart.
+If the user asks for "why", combine AnomalyCallout with SegmentBreakdown.
+If the user needs to act, include FollowupActions with concrete next steps.
+```
+
+That changes the economics of dashboard work. Engineers still build the primitives. Designers still define visual language. Analysts still define trusted metrics. But many one-off layout decisions move from a ticket queue into runtime composition.
+
+## A Concrete Example: Support Operations
+
+Imagine a support operations dashboard. The static version has:
+
+- Tickets by status
+- First response time
+- Average resolution time
+- CSAT
+- Escalation count
+- Top tags
+
+That is useful. It is also generic.
+
+Now a support lead asks:
+
+> Show me why enterprise escalations increased this week.
+
+A living interface could render a task-specific view:
+
+```text
+<Dashboard title="Enterprise escalation drivers">
+  <MetricCard label="Escalations" value="47" delta="+31%" tone="warning" />
+  <MetricCard label="Median time to first human reply" value="3h 12m" delta="+42%" />
+  <LineChart title="Escalations by day" series="enterpriseEscalations" />
+  <DataTable
+    title="Top contributing tags"
+    columns=["tag", "tickets", "change", "median_age", "owner"]
+    rows="topEscalationTags"
+  />
+  <Alert
+    title="Likely driver"
+    body="Billing and SSO tickets account for 68% of the increase. Both show delayed first human response after the routing rule change on Monday."
+  />
+  <ActionList actions=["Open routing rule audit", "Compare with SMB tickets", "Draft escalation summary"] />
+</Dashboard>
+```
+
+That is not the same as a chatbot saying the answer aloud or writing it in prose. It gives the user a compact workspace: overview, evidence, likely cause, and next actions.
+
+The static dashboard remains useful for daily monitoring. The generated view is useful for investigation.
+
+## Streaming Matters More Than It Sounds
+
+One reason OpenUI's streaming-first design matters is that generated interfaces should not feel like reports that appear after a long blank pause.
+
+OpenUI Lang is designed so model output can be parsed and rendered progressively as tokens arrive. The OpenUI README describes a streaming renderer that updates the UI as output arrives, and its benchmark section reports that OpenUI Lang is substantially more token-efficient than JSON-based formats across several UI scenarios.
+
+That has two product implications.
+
+First, users get feedback earlier. A heading, summary card, or skeleton can appear while the rest of the table or chart is still being generated. For analytical workflows, perceived progress matters. A blank screen makes the user wonder whether the agent is stuck.
+
+Second, the UI can stay interactive as it grows. In the Thesys voice-agent reference implementation, the agent streams generated visual UI over a LiveKit text stream with the topic `genui`, and the frontend registers a handler for that stream. As content arrives, the React UI passes the accumulated response into a `C1Component`. That is the same mental model a dashboard product needs: generated structure should appear incrementally, not as a final blob.
+
+In a data product, that might look like:
+
+1. Render the question restatement and primary KPI cards.
+2. Stream in the anomaly explanation.
+3. Add the table once the query result arrives.
+4. Add follow-up actions after the model sees the evidence.
+
+The interface becomes a live conversation between data, model, and user.
+
+## The Hard Parts
+
+Living interfaces are not magic. They move complexity around.
+
+Data correctness becomes the first hard problem. A generated chart is only useful if it is grounded in trusted queries. The model should not be calculating revenue from raw rows in free-form text. It should call a tool or API that returns typed, verified results, then choose how to present them.
+
+Component constraints are the second hard problem. The more freedom the model has, the more inconsistent the product becomes. A good generative UI system should expose a curated component library, not an open-ended canvas. Designers still own the design system. The model composes within it.
+
+Reproducibility is the third hard problem. Some dashboards must be stable because users need to compare the same view over time. A generated interface can still log the prompt, data snapshot, component tree, and model version, but that requires deliberate instrumentation.
+
+Latency is the fourth hard problem. A static dashboard can precompute and cache aggressively. A living interface may need to retrieve data, ask the model to plan a view, stream UI, and handle follow-up actions. The product needs a latency budget:
+
+- Which data queries must finish before rendering starts?
+- Which parts can stream later?
+- Which generated views should be cached?
+- When should the system fall back to a static chart or text summary?
+
+Finally, there is trust. If users cannot tell where a number came from, they will not use the interface for serious work. Generated dashboards need source links, query provenance, timestamps, and visible assumptions.
+
+## When Static Dashboards Are Still Better
+
+Static dashboards are not going away. They are the right tool when:
+
+- The view is a shared organizational source of truth.
+- The same metric needs to be reviewed repeatedly.
+- Auditability matters more than personalization.
+- The task is monitoring rather than exploration.
+- The cost of a wrong layout is high.
+
+A finance close dashboard, an uptime page, a compliance report, or a board KPI deck should not reshape itself casually.
+
+The living interface belongs next to those surfaces, not necessarily instead of them. Think of it as the exploratory layer: a way to ask new questions without waiting for the dashboard backlog to catch up.
+
+## What Teams Should Build First
+
+The best first use case is not "replace our BI tool with AI." That is too broad.
+
+Start with one workflow where users already ask for custom views:
+
+- Support escalation analysis
+- Sales pipeline inspection
+- Product funnel debugging
+- Marketing campaign comparison
+- Usage analytics for customer success
+- Incident postmortem exploration
+
+Then define a narrow component set:
+
+- One or two metric cards
+- One table
+- One time-series chart
+- One breakdown chart
+- One callout component
+- One action list
+
+Add a tool layer that returns trusted data. Give the model the component contracts. Log the generated component tree. Let users give feedback on whether the generated view answered their question.
+
+Measure the result like a product feature:
+
+- Did users complete the task without exporting data?
+- Did they ask fewer follow-up questions in Slack?
+- Did time-to-insight fall?
+- Which generated components were used most often?
+- Which prompts produced confusing layouts?
+
+If those numbers move, expand the component vocabulary.
+
+## The Interface Is Becoming The Answer
+
+The old dashboard model assumed that teams could predict the right set of views in advance. Sometimes they can. Often they cannot.
+
+Generative UI changes that assumption. The product team can define safe building blocks, data boundaries, and design rules, then let the interface assemble itself around the user's current question.
+
+That is the real shift from static dashboards to living interfaces. Not dashboards that wiggle. Not charts with AI summaries pasted underneath. A working surface that appears at the moment of need, shaped by the task, grounded in real data, and constrained enough to be trusted.
+
+For developers, the opportunity is not to make every interface unpredictable. It is to stop hardcoding temporary analytical views as permanent product surfaces.
+
+The dashboard of the future is not one page with more filters.
+
+It is a system that knows when to show the stable view, when to generate the task-specific view, and how to keep both connected to the same source of truth.
+
+## References
+
+- OpenUI repository: https://github.com/thesysdev/openui
+- OpenUI documentation and playground: https://www.openui.com/
+- Thesys voice-agent generative UI demo: https://github.com/thesysdev/voice-agent-generativeui
+- LiveKit Agents documentation: https://docs.livekit.io/agents/


### PR DESCRIPTION
## Summary

Adds the article draft for #8: "From Static Dashboards to Living Interfaces: How AI Is Redefining the Way We Display Data".

The piece frames living interfaces as task-specific, runtime-composed data surfaces, with OpenUI introduced as a concrete technical foundation rather than as a product pitch.

## Validation

- Markdown-only change
- Ran `git diff --check` before splitting the submission

Related to #8.
