### PR TITLE
Article: UI-based chatbots vs text-based chatbots

### DIFF
--- a/Articles/UI-Based Chatbots vs Text-Based Chatbots.md
+++ b/Articles/UI-Based Chatbots vs Text-Based Chatbots.md
@@ -1,0 +1,245 @@
+# UI-Based Chatbots vs. Text-Based Chatbots: A Performance Comparison Across Task Completion Rate, Time-on-Task, and User Satisfaction
+
+Most chatbot benchmarks still measure the model, not the interface.
+
+That made sense when the product was a blank text box wrapped around a language model. But the next wave of AI products is not just answering questions. It is helping users compare plans, configure workflows, file tickets, inspect data, buy products, approve changes, and make decisions with consequences.
+
+For those tasks, the interface is not decoration. It changes the outcome.
+
+A text-only chatbot and a UI-based chatbot can use the same model, retrieve the same data, and give the same final answer. They can still perform very differently because users do not only need an answer. They need to understand the answer, check it, adjust it, and act on it.
+
+This article compares text-based and UI-based chatbots across three product metrics teams already care about:
+
+- task completion rate
+- time-on-task
+- user satisfaction
+
+The short version: text chat is good for open-ended language work, but it becomes a bottleneck when the task has structure. UI-based chatbots win when the user needs to scan options, manipulate parameters, compare data, confirm state, or take action safely.
+
+## What Counts as a UI-Based Chatbot?
+
+A text-based chatbot returns prose, lists, markdown tables, and maybe links. The user acts by typing another message.
+
+A UI-based chatbot can return interactive components: tables, charts, forms, cards, filters, tabs, previews, buttons, timelines, editors, and confirmation flows. The user can still chat, but they are no longer forced to express every action as text.
+
+OpenUI describes this as letting the model compose the interface itself from a predefined component library. The important constraint is "predefined." The model is not shipping arbitrary JavaScript to the browser. It selects, configures, and composes components your application already knows how to render.
+
+That distinction matters. UI-based chatbots are not just prettier chat bubbles. They are a different interaction contract:
+
+- The model proposes structure.
+- The application validates that structure.
+- The renderer turns it into interactive UI.
+- The user can act directly on the UI instead of translating intent back into another prompt.
+
+In OpenUI terms, this is handled through a component library, prompt generator, parser, and renderer. The library defines what the model is allowed to use. The parser validates streamed output against that contract. The renderer maps the result to real React components.
+
+That architecture gives product teams a practical middle path between two bad options: plain text that is flexible but hard to act on, and hardcoded UI that is safe but too rigid for AI-native workflows.
+
+## Metric 1: Task Completion Rate
+
+Task completion rate measures whether users can finish the thing they came to do. It is the first metric to watch because a delightful interface that fails the task is still a failed product.
+
+Text-based chatbots struggle with completion when the task requires the user to maintain state in their head. A user comparing insurance plans, cloud costs, contract clauses, or analytics anomalies has to keep rereading the conversation. They need to remember which option had which tradeoff, which assumptions changed, and what the assistant already confirmed.
+
+UI changes that. A UI-based chatbot can externalize state:
+
+- comparison tables keep options visible
+- forms show required fields and validation errors
+- charts reveal outliers faster than paragraphs
+- cards make recommendations scannable
+- confirmation panels show exactly what will happen before an action runs
+
+This is not a new UX principle. Graphical interfaces have repeatedly shown advantages for structured tasks because they reduce recall burden and expose available actions. A classic medical-order-entry study comparing text-based and graphical interfaces found better performance with the GUI on completion, accuracy, frustration, fatigue, and learning measures. The exact domain is old, but the lesson is still relevant: when the task has structured objects and repeated decisions, visible controls help users complete more of the work.
+
+Modern chatbot products rediscover this the hard way. A support bot that says "I can help you change your plan" still needs a plan selector, current plan summary, price delta, billing date, and confirmation step. If all of that is text, users must trust the assistant's narration. If it is UI, they can verify and act.
+
+Where UI-based chatbots usually improve completion:
+
+- multi-step forms where users must provide specific inputs
+- search and filtering tasks where users need to refine a result set
+- comparison tasks with more than two options
+- workflows with irreversible or expensive actions
+- analytics tasks where the answer depends on inspecting a distribution, trend, or segment
+
+Where text may still be enough:
+
+- summarization
+- brainstorming
+- drafting
+- lightweight Q&A
+- exploratory conversation before the user knows what they need
+
+The dividing line is simple: if the user needs to manipulate or verify structured information, the chatbot should probably generate UI.
+
+## Metric 2: Time-on-Task
+
+Time-on-task is not about making every interaction faster. Sometimes a safer flow intentionally adds a confirmation step. But for most product work, unnecessary time is friction.
+
+Text-based chatbots create hidden time costs:
+
+1. The user has to parse prose.
+2. The user has to decide what parts are actionable.
+3. The user has to ask follow-up questions to change parameters.
+4. The model has to restate context on every turn.
+5. The user has to wait for another generated response.
+
+UI-based chatbots shorten that loop by letting the next action happen in the interface. If a user asks, "Which invoices are overdue and worth escalating?", a text answer can list invoices. A UI answer can show a sorted table with filters, risk badges, amount totals, and escalation buttons. The next move is a click, not another prompt.
+
+The same pattern appears in search UX. Baymard's research on autocomplete argues that suggestions are valuable not merely because they save keystrokes, but because they guide users toward better queries, correct terminology, and the right search scope. That is exactly the role a generated UI can play inside chat: it turns a vague intent into better next actions.
+
+Consider a data-analysis bot:
+
+Text-only flow:
+
+1. User asks for churn drivers.
+2. Bot returns a paragraph and a markdown table.
+3. User asks to segment by plan.
+4. Bot returns another table.
+5. User asks to exclude trials.
+6. Bot returns another answer.
+7. User asks for enterprise accounts only.
+
+UI-based flow:
+
+1. User asks for churn drivers.
+2. Bot returns a chart, ranked factor table, and filter controls.
+3. User toggles plan, trial status, and account segment directly.
+4. Bot updates the view or runs the next tool call with explicit parameters.
+
+The difference is not just fewer turns. It is less translation. The user does not have to repeatedly encode interface operations as natural language. The model does not have to repeatedly decode them.
+
+OpenUI's streaming model is relevant here. The official docs describe a parser and renderer that can progressively render UI as output arrives. That matters because perceived speed is part of time-on-task. A user who sees a table shell, partial rows, or a chart forming can begin orienting before the full response is complete.
+
+Text streams well, but text streams linearly. UI can stream spatially: structure first, details second.
+
+## Metric 3: User Satisfaction
+
+User satisfaction is not the same as task completion. Users can complete a task and still dislike the system if it feels opaque, slow, or risky.
+
+Microsoft research on intelligent assistants found that satisfaction depends on the scenario. For some tasks, completion matters most. For others, effort is more important. The work also highlights that overall task-level satisfaction cannot be reduced to individual query satisfaction. That is a useful warning for chatbot teams: a model can produce a good answer to each turn while the whole experience still feels laborious.
+
+UI-based chatbots can improve satisfaction because they make the system feel more controllable.
+
+Users generally like assistants more when they can answer these questions:
+
+- What did the assistant understand?
+- What data is it using?
+- What can I change?
+- What will happen if I approve this?
+- How do I undo or refine the result?
+
+Text can explain those things. UI can show them.
+
+For example, a procurement assistant that recommends a vendor should not only say "Vendor B is best." It should show the scorecard: price, risk, compliance status, delivery time, contract exceptions, and confidence. A human can then challenge the recommendation. Maybe risk should count more than price. Maybe a vendor has a pending legal review. Maybe the user wants to exclude vendors without SOC 2.
+
+That kind of trust-building is hard in pure chat because every correction becomes another conversational turn. In UI, the user can see the levers.
+
+This also reduces one of the most annoying chatbot failure modes: the assistant sounds confident while hiding uncertainty. A UI-based answer can make uncertainty visible through confidence labels, missing-data warnings, disabled actions, or review-required states. That gives users a more honest experience.
+
+## The Hybrid Pattern Usually Wins
+
+The strongest AI interfaces are not "chat instead of UI" or "UI instead of chat." They are hybrid.
+
+Chat is good for intent capture:
+
+- "Show me customers at risk this month."
+- "Help me compare these three candidates."
+- "Create a launch checklist for this feature."
+
+UI is good for stateful work:
+
+- filtering customers
+- editing weights
+- approving outreach
+- comparing candidates
+- checking checklist dependencies
+
+The pattern looks like this:
+
+1. User describes intent in natural language.
+2. Assistant generates a purpose-built interface.
+3. User manipulates the interface.
+4. Assistant updates the result, calls tools, or explains tradeoffs.
+5. User confirms the final action.
+
+That is why generative UI is more than an output format. It is an interaction model.
+
+## Product Examples
+
+### Customer Support
+
+A text bot can explain a refund policy. A UI-based bot can show eligible orders, refund amount, method, timeline, and a confirm button. Completion improves because the user does not need to copy order IDs or ask which purchase qualifies.
+
+### Analytics
+
+A text bot can summarize revenue movement. A UI-based bot can return a chart, segment picker, anomaly list, and drill-down table. Time-on-task improves because users can inspect the data directly.
+
+### Internal Tools
+
+A text bot can say how to create a deployment freeze. A UI-based bot can generate the freeze form with service selector, environment, start/end time, approvers, and rollback notes. Satisfaction improves because users can see exactly what will be submitted.
+
+### Shopping and Research
+
+A text bot can list recommended products. A UI-based bot can display cards with price, constraints, comparison columns, availability, and filters. This avoids the familiar problem where users ask for "the best option" and then spend five more turns extracting criteria the interface could have shown from the start.
+
+## What Developers Need to Build This Well
+
+UI-based chatbots require more discipline than text chat. The model cannot be allowed to invent arbitrary UI primitives or unsafe actions.
+
+A production-ready approach needs:
+
+- a bounded component library
+- schema validation
+- streaming-safe parsing
+- clear empty/loading/error states
+- explicit action boundaries
+- telemetry for completion, time-on-task, and satisfaction
+- fallbacks to text when UI is unnecessary
+
+This is where frameworks like OpenUI become useful. OpenUI is not valuable merely because it can render components from model output. The deeper value is the contract: define components with schemas, generate prompts from that library, parse output into a typed tree, and render it through your application components.
+
+That gives teams a way to ship generative interfaces without handing the model the keys to the frontend.
+
+## How to Measure the Difference
+
+If you are deciding whether to move a chatbot flow from text-only to UI-based, do not rely on taste. Run a task study.
+
+Pick three to five realistic tasks:
+
+- complete a refund
+- compare three plans
+- identify the riskiest accounts
+- configure an automation
+- create a report and export it
+
+For each variant, measure:
+
+- completion rate: did the user finish correctly?
+- time-on-task: how long did it take?
+- turns per task: how many messages were needed?
+- correction rate: how often did the user have to clarify or repair?
+- confidence: did the user feel sure before acting?
+- satisfaction: would they use this again?
+
+Also log where users switch modes. If they start in chat but repeatedly ask for tables, filters, previews, or buttons, that is a signal that the product needs generated UI. If they ignore the UI and keep talking, the component may be too rigid or unnecessary.
+
+## The Practical Takeaway
+
+Text chat is a strong interface for language. It is a weak interface for structured action.
+
+UI-based chatbots improve performance when the task depends on visible state, direct manipulation, comparison, validation, and confirmation. They can raise task completion by making options and actions explicit. They can reduce time-on-task by replacing repeated prompt turns with controls. They can improve satisfaction by making the assistant's reasoning, data, and uncertainty easier to inspect.
+
+That does not mean every response should become a dashboard. The best systems use text when the task is conversational and generate UI when the task becomes operational.
+
+For developers, the question should shift from "Should my AI app have chat?" to "At what moment does chat stop being the right interface?"
+
+That moment is usually earlier than it looks.
+
+## References
+
+- [OpenUI documentation: Introduction](https://www.openui.com/docs)
+- [OpenUI documentation: OpenUI Lang overview](https://www.openui.com/docs/openui-lang/overview)
+- [OpenUI GitHub repository](https://github.com/thesysdev/openui)
+- [Baymard: Autocomplete Suggestions UX benchmark](https://baymard.com/ecommerce-search/benchmark/page-types/autocomplete-suggestions)
+- [Microsoft Research: Understanding User Satisfaction with Intelligent Assistants](https://www.microsoft.com/en-us/research/publication/understanding-user-satisfaction-intelligent-assistants/)
+- [Comparing Response Time, Errors, and Satisfaction Between Text-based and Graphical User Interfaces During Nursing Order Tasks](https://pmc.ncbi.nlm.nih.gov/articles/PMC61470/)


### PR DESCRIPTION
Closes #9.

## Summary
- Added a 2,200+ word research-backed article comparing UI-based and text-based chatbots across task completion rate, time-on-task, and user satisfaction.
- Positions OpenUI as a practical implementation path for bounded, schema-backed generative UI rather than as a generic product pitch.
- Includes source links to OpenUI docs/GitHub and UX/HCI references from Baymard, Microsoft Research, and PubMed Central.

## Verification
- Checked article length, required sections, references, and balanced Markdown fences.
- `git diff --check`
