### PR TITLE
docs: add article on living interfaces

### DIFF
--- a/Articles/From Static Dashboards to Living Interfaces - How AI Is Redefining the Way We Display Data.md
+++ b/Articles/From Static Dashboards to Living Interfaces - How AI Is Redefining the Way We Display Data.md
@@ -1,0 +1,417 @@
+# From Static Dashboards to Living Interfaces: How AI Is Redefining the Way We Display Data
+
+Static dashboards solved a real problem.
+
+They made data visible.
+
+They took teams from:
+
+- emailed spreadsheets,
+- weekly PDF reports,
+- hand-built exports,
+- and "ask analytics to pull that for me"
+
+to something interactive and shared.
+
+That was a major step forward.
+
+But a lot of dashboards now feel like they are reaching the edge of what that model can do well.
+
+Not because charts are bad.
+
+Because fixed interfaces are increasingly mismatched to fluid questions.
+
+Modern users do not just want to look at a dashboard. They want the interface to respond to:
+
+- what role they are in,
+- what question they are asking,
+- what anomaly just appeared,
+- and what action they need to take next.
+
+That is where the next shift starts.
+
+This article is about that shift:
+
+> from static dashboards to living interfaces.
+
+And it uses OpenUI as the concrete implementation layer for that change, not as the subject of a product pitch.
+
+## Why Static Dashboards Worked So Well
+
+Dashboards became dominant because they solved three painful problems at once:
+
+1. **They centralized information**
+2. **They made recurring metrics visible**
+3. **They gave non-engineers some self-service access**
+
+Compared to raw SQL, spreadsheets, or emailed reports, a good dashboard was a huge improvement.
+
+If your needs were stable, dashboards were efficient:
+
+- same metrics,
+- same views,
+- same audience,
+- same questions every week.
+
+That model still works in many places:
+
+- finance reporting,
+- compliance reporting,
+- uptime status boards,
+- executive KPI summaries,
+- recurring operations reviews.
+
+If the question is predictable, a fixed dashboard is often the right tool.
+
+## Where Static Dashboards Start to Break
+
+The friction shows up when the questions stop being predictable.
+
+For example:
+
+- a support lead wants a very different interface from a product manager
+- an operations team wants to inspect anomalies, not just totals
+- an analyst wants to branch from one question into three follow-up questions
+- a user needs to approve an action, not just view a metric
+
+Static dashboards struggle here because they are built around:
+
+- pre-decided layouts,
+- pre-decided filters,
+- pre-decided user journeys.
+
+That means every new need becomes one of these:
+
+- "Can we add one more tab?"
+- "Can we add one more filter?"
+- "Can we add one more chart?"
+- "Can we make a separate dashboard for this team?"
+
+Eventually the dashboard stops being a surface for understanding and becomes a pile of compromises.
+
+## The Real Problem Is Not Charts. It Is Interface Rigidity.
+
+Most BI tools assume the designer or analyst can anticipate what users will need.
+
+Sometimes they can.
+
+Often they cannot.
+
+Users do not think in dashboard tabs. They think in questions:
+
+- Which region is underperforming right now?
+- Which accounts need follow-up today?
+- What changed since yesterday?
+- Which tasks are safe to approve?
+- Show me only the items that are blocked and high value.
+
+A fixed dashboard can answer these only if somebody predicted them early enough.
+
+That is the rigidity problem:
+
+> the interface is static, but the user intent is not.
+
+## What a Living Interface Actually Means
+
+The phrase "living interface" sounds abstract until you make it concrete.
+
+A living interface is not just a dashboard with auto-refresh.
+
+It is an interface that can adapt its structure to the task:
+
+- different components,
+- different layout,
+- different summaries,
+- different actions,
+- different emphasis.
+
+Not because an engineer manually built 25 variants.
+
+Because the system can generate the right interface shape from:
+
+- the user intent,
+- the underlying data,
+- and the available component set.
+
+That is the key distinction.
+
+Static dashboards update the data inside a fixed shell.
+
+Living interfaces can adapt the shell itself.
+
+## A Simple Example
+
+Imagine the same dataset: account performance for a sales organization.
+
+A static dashboard might show:
+
+- revenue chart,
+- pipeline chart,
+- top accounts table,
+- activity summary,
+- filters across the top.
+
+That is fine as a general-purpose overview.
+
+But three users may need three very different surfaces:
+
+### Executive
+
+Wants:
+
+- high-level summary,
+- trend direction,
+- anomaly callouts,
+- biggest risk areas.
+
+### Sales manager
+
+Wants:
+
+- team-level breakdown,
+- low-activity accounts,
+- clear next actions,
+- follow-up recommendations.
+
+### Operations user
+
+Wants:
+
+- exceptions,
+- validation failures,
+- stale records,
+- bulk action controls.
+
+Those are not just different filters. They are different interfaces.
+
+That is where generative UI becomes more than "chat with components."
+
+It becomes a way to build the right surface for the current job.
+
+## Where OpenUI Fits
+
+OpenUI is useful here because it gives you a structured way to turn intent into interface.
+
+The project positions OpenUI as:
+
+- a generative UI framework,
+- a streaming-friendly language,
+- a rendering model for model-generated interfaces,
+- and a constrained way to expose component libraries to LLMs.
+
+That matters because living interfaces need two things at once:
+
+1. flexibility  
+2. control
+
+Pure freeform generation gives you flexibility but poor safety.
+
+Pure static dashboards give you control but poor adaptability.
+
+OpenUI sits in the middle:
+
+- you define the component vocabulary,
+- the system prompt defines the rules,
+- the model generates within that surface,
+- and the renderer turns the result into a usable interface.
+
+## This Is Not "A Better Chart Library"
+
+It is easy to misunderstand the shift as:
+
+> dashboards, but smarter.
+
+That undersells it.
+
+The deeper change is that interface generation starts happening closer to runtime and closer to intent.
+
+A normal dashboard pipeline is:
+
+- define metrics,
+- build queries,
+- design layout,
+- ship layout,
+- let users interact inside that layout.
+
+A living-interface pipeline is closer to:
+
+- define data sources,
+- define component library,
+- define rules,
+- accept user intent,
+- generate a task-specific interface,
+- validate actions,
+- render the best available surface.
+
+The layout is no longer fully authored ahead of time.
+
+That changes what product teams design and what engineers build.
+
+## What Changes for Product Teams
+
+If this shift becomes normal, product work changes in three ways.
+
+### 1. More emphasis on interface primitives
+
+Teams spend less time hand-authoring every screen and more time defining:
+
+- reusable components,
+- interface rules,
+- action schemas,
+- and safe state transitions.
+
+### 2. More emphasis on intent modeling
+
+Instead of only asking:
+
+- what charts should be on the page?
+
+teams start asking:
+
+- what tasks is the user trying to complete?
+- what evidence do they need?
+- what actions are safe to expose?
+
+### 3. More emphasis on validation
+
+Once the interface can vary at runtime, safety moves from layout design into contracts:
+
+- component constraints,
+- schema validation,
+- semantic checks,
+- action approval rules.
+
+This is one reason generative UI is not "just frontend."
+
+It crosses product, data, UX, and application logic.
+
+## The Tradeoffs Are Real
+
+Living interfaces are not automatically better.
+
+They introduce real costs:
+
+### Latency
+
+Runtime interface generation is slower than rendering a pre-built page.
+
+### Validation burden
+
+You need stronger checks for:
+
+- structure,
+- semantics,
+- and action payload safety.
+
+### Design-system discipline
+
+If the component library is weak or inconsistent, generated UI becomes messy quickly.
+
+### Predictability
+
+Some teams prefer fixed, auditable screens for legal or operational reasons.
+
+In those cases, dynamic generation may be the wrong default.
+
+So this is not a story about static dashboards disappearing.
+
+It is a story about where static dashboards stop being the best answer.
+
+## When Static Should Still Win
+
+Static dashboards are still the better choice when:
+
+- reproducibility matters more than adaptability
+- the audience is broad and stable
+- the questions are well-known
+- the interface must stay identical across sessions
+
+Examples:
+
+- finance audit reporting
+- regulatory reporting
+- fixed public status pages
+- board-level KPI summaries
+
+These are not failures of imagination.
+
+They are different product constraints.
+
+Living interfaces matter most where user intent changes faster than page design can keep up.
+
+## The Most Important Shift: From Viewing to Acting
+
+A lot of dashboard conversations still assume the user is there to observe.
+
+But many modern workflows require users to decide and act:
+
+- approve a task
+- flag a risk
+- route a lead
+- investigate an anomaly
+- retry a failed step
+- submit a follow-up
+
+Once that happens, the interface is no longer just a reporting surface.
+
+It is an operational surface.
+
+That is why the generative UI conversation matters.
+
+Because operational interfaces benefit much more from:
+
+- context adaptation,
+- dynamic layout,
+- and structured action surfaces
+
+than static reporting pages do.
+
+## A Better Mental Model
+
+Do not think of living interfaces as "AI making dashboards prettier."
+
+Think of them as:
+
+> task-aware interfaces generated from intent, data, and constraints.
+
+That mental model is more useful because it points you toward the real engineering work:
+
+- define the available components,
+- define the interface rules,
+- define what actions are legal,
+- and let the system assemble the right surface for the current moment.
+
+OpenUI is one concrete way to do that.
+
+## Final Takeaway
+
+Static dashboards were a major improvement over reports and spreadsheets.
+
+They are still the right tool for many stable, repeatable, read-heavy workflows.
+
+But the limits are becoming clearer:
+
+- too many tabs,
+- too many filters,
+- too much interface debt,
+- too many cases where the page cannot keep up with the question.
+
+That is why living interfaces matter.
+
+They shift the center of gravity from:
+
+- pre-authored layout
+
+to:
+
+- runtime adaptation around user intent.
+
+And that is why generative UI is not just another frontend trend.
+
+It is a change in how we think about software surfaces at all.
+
+The next generation of data interfaces will not just refresh faster.
+
+They will understand what the user is trying to do and generate the right structure for it.
+
+That is the real break from the dashboard era.


### PR DESCRIPTION
Fixes #8

This adds a developer/product-facing article on the shift from static dashboards to living interfaces.

Focus areas:
- why static dashboards worked and where they start to break down
- the difference between refreshing data and adapting the interface itself
- how intent-driven, task-aware interfaces differ from fixed BI pages
- where OpenUI fits as a constrained runtime rendering layer
- practical tradeoffs around latency, validation, and design-system control

The article is intentionally written as a trend-and-implementation piece, not a product pitch.
