### PR TITLE
docs: add article on progressive hydration

### DIFF
--- a/Articles/OpenUI's React Renderer Explained - How Progressive Hydration Works with Streamed Model Output.md
+++ b/Articles/OpenUI's React Renderer Explained - How Progressive Hydration Works with Streamed Model Output.md
@@ -1,0 +1,346 @@
+# OpenUI's React Renderer Explained: How Progressive Hydration Works with Streamed Model Output
+
+Most AI apps wait too long to render.
+
+They stream tokens, but the interface stays blank until the model has finished enough output to become valid JSON or valid application state.
+
+That creates a familiar user experience:
+
+- spinner,
+- spinner,
+- spinner,
+- full render all at once.
+
+OpenUI takes a different path.
+
+Instead of treating UI generation as "wait until the output is complete, then parse it," OpenUI is built around a more useful assumption:
+
+> partial output can still become meaningful UI before the model is done.
+
+That is what makes progressive hydration interesting here.
+
+This article explains the idea from a practical React developer angle:
+
+- why streamed model output is awkward for normal rendering pipelines
+- why OpenUI Lang is a better fit than full JSON blobs
+- how partial output becomes a partial tree
+- how React can keep rendering useful state while the stream is still growing
+- what still breaks, and what you still need to guard
+
+## The Core Problem: React Likes Trees, Models Emit Tokens
+
+React wants something tree-like:
+
+- components,
+- props,
+- children,
+- boundaries,
+- state transitions.
+
+LLMs do not emit trees.
+
+They emit tokens over time.
+
+That mismatch is the first problem in progressive rendering.
+
+If your model is outputting raw JSON, you often cannot safely parse anything until:
+
+- braces are balanced,
+- nested arrays are complete,
+- strings are closed,
+- and the schema is whole enough to validate.
+
+Until then, there is no real UI tree. There is just an incomplete string.
+
+That is one reason many "AI UI" demos feel slower than they should. The model may be streaming, but the renderer is still effectively blocking.
+
+## Why OpenUI Lang Helps
+
+OpenUI Lang matters because it was designed for structured UI generation under streaming conditions.
+
+That does not mean malformed output disappears.
+
+It means the representation is friendlier to incremental interpretation than a giant JSON object that cannot survive partial parsing.
+
+In practical terms, OpenUI gets a few advantages:
+
+- the generated structure is closer to UI intent than to generic serialization
+- partial component boundaries can emerge earlier
+- the parser can keep a best-effort partial tree instead of treating everything as invalid until the last brace
+
+This is the key design difference:
+
+> the format is built for "render as the stream becomes meaningful," not just "parse after completion."
+
+## A Better Mental Model for Progressive Hydration
+
+Think of progressive hydration here as a rolling sequence of four states:
+
+1. raw token stream
+2. partial parse state
+3. best-available component tree
+4. rendered React output
+
+Each new chunk of model output can improve the tree without requiring the whole response to be complete.
+
+That means the interface can evolve like this:
+
+- first a container appears
+- then a title and summary
+- then a table shell
+- then rows
+- then actions
+- then richer details
+
+The user sees movement toward usefulness, not just delayed completeness.
+
+## What the Renderer Is Really Doing
+
+The OpenUI renderer is not just "rendering streamed text."
+
+It is continuously trying to answer:
+
+- what can I safely materialize now?
+- what is incomplete but recoverable?
+- what was previously valid and should stay on screen?
+- what should be deferred until more tokens arrive?
+
+That usually leads to a more resilient rendering posture than a naive "parse whole payload every time" loop.
+
+A naive pipeline often does this:
+
+1. receive stream chunk
+2. append to string
+3. try full parse
+4. if parse fails, show nothing or keep spinner
+
+An OpenUI-style pipeline is better when it can instead do something closer to:
+
+1. receive stream chunk
+2. update partial parse state
+3. recover the largest valid subtree
+4. keep already valid UI mounted
+5. upgrade the rendered tree when more structure becomes available
+
+That difference is what users feel as responsiveness.
+
+## Why \"Wait for Full JSON\" Is the Wrong Baseline
+
+A lot of teams compare generative UI rendering against a pipeline that waits for complete JSON and then renders a final React tree.
+
+That is a weak baseline for two reasons:
+
+### 1. It hides early structure
+
+Many useful UI fragments are already stable before the whole response is complete.
+
+### 2. It makes every partial error catastrophic
+
+If the parser only accepts complete payloads, then every in-progress state is effectively a failure state.
+
+That pushes you toward:
+
+- longer blank periods,
+- larger layout jumps,
+- worse perceived latency.
+
+OpenUI's advantage is not just that it streams. It is that it gives the renderer something more useful to do while streaming.
+
+## A Practical Example
+
+Imagine the model is generating a review surface for candidate tasks.
+
+At the end of the stream, you want:
+
+- title,
+- short explanation,
+- three task cards,
+- approve/reject actions.
+
+With a blocking pipeline, nothing renders until all of that is complete.
+
+With a progressive one, the evolution can be:
+
+### Early stream
+
+- page title
+- loading copy
+
+### Mid stream
+
+- explanation text
+- task card shells
+
+### Later stream
+
+- confidence values
+- risk badges
+- action buttons
+
+### Final stream
+
+- full action payload wiring
+- extra details
+
+The user is never staring at a blank page that is technically "streaming."
+
+They are watching the UI become more useful.
+
+## Fallback Boundaries Matter More Than Perfect Parsing
+
+A common mistake is to think progressive hydration is mainly a parser problem.
+
+It is not.
+
+It is also a fallback-boundary problem.
+
+You need to decide:
+
+- what remains visible if the newest stream chunk is malformed?
+- what parts of the previous render stay trusted?
+- what parts of the new render are provisional?
+
+This is where defensive rendering matters.
+
+A good progressive UI should prefer:
+
+- keeping the last valid subtree visible
+- dropping only the broken in-progress fragment
+- surfacing recoverable errors as local state
+
+instead of:
+
+- unmounting everything
+- replacing the whole UI with an error
+- or forcing a full reset
+
+That is the difference between resilient progression and flashing instability.
+
+## The Three Failure Modes You Still Need to Respect
+
+OpenUI does not remove failure. It changes how failure shows up.
+
+### 1. Incomplete props
+
+The component type is known, but required props are not all there yet.
+
+The renderer has to decide:
+
+- defer render,
+- render placeholder state,
+- or render a partial component safely.
+
+### 2. Malformed nested structure
+
+The model starts one component and then drifts into invalid nesting.
+
+This is where partial-tree recovery becomes important. The renderer should salvage what is still structurally safe.
+
+### 3. Semantically wrong but valid UI
+
+The output parses and renders fine, but it is the wrong interface.
+
+This is not a hydration problem alone. It becomes a validation problem:
+
+- schema checks,
+- semantic checks,
+- action guardrails.
+
+Progressive hydration helps with responsiveness. It does not solve correctness by itself.
+
+## Where React Actually Helps
+
+React is useful here because it is already good at reconciling changing trees.
+
+The tricky part is not React.
+
+The tricky part is feeding React a sequence of trees that:
+
+- stay stable enough to avoid jank
+- change meaningfully enough to show progress
+- preserve already-valid subtrees
+
+If the renderer emits wildly different trees from chunk to chunk, users see:
+
+- remount storms,
+- layout jumps,
+- focus loss,
+- broken input state.
+
+So the real goal is not "re-render on every token."
+
+The goal is:
+
+> update the best-available tree only when the next meaningful UI unit becomes safe to render.
+
+That is a much better target than token-by-token paint.
+
+## What Developers Should Validate
+
+If you are building on top of this model, the most important checks are not just parser tests.
+
+You want to validate:
+
+- structural validity of partial trees
+- stability of already-mounted nodes
+- action bindings after final hydration
+- fallback behavior under malformed output
+- time to first meaningful render
+
+Those metrics and tests tell you much more than "the parser works."
+
+Because users do not experience the parser.
+
+They experience:
+
+- whether something useful appeared quickly
+- whether the UI stayed stable
+- whether actions worked when they clicked them
+
+## The Architectural Tradeoff
+
+OpenUI's progressive model has a real advantage over "full JSON first" systems, but it also comes with tradeoffs:
+
+### Pros
+
+- faster perceived responsiveness
+- more graceful partial rendering
+- better fit for structured streamed UI generation
+- less dead time before the user sees something useful
+
+### Cons
+
+- more renderer complexity
+- more need for partial-state validation
+- harder debugging when malformed streams still partially render
+- more subtle reconciliation bugs if tree stability is not controlled
+
+That is why this architecture is compelling for teams that actually need streaming UI, not just for teams who want a flashy demo.
+
+## The Most Important Takeaway
+
+Progressive hydration in OpenUI is not magic.
+
+It is a design choice:
+
+- choose a stream-friendly UI language
+- parse incrementally
+- preserve best-available structure
+- render useful subtrees early
+- keep fallback boundaries strong
+
+That is what turns streaming from a transport detail into a user-experience feature.
+
+Without that, "streaming UI" often just means:
+
+- the backend is busy,
+- the browser is waiting,
+- and the spinner spins with more technical sophistication.
+
+With it, the interface can become meaningfully interactive before the model is finished.
+
+That is the real promise here.
+
+Not just that the model streams.
+
+But that the user no longer has to wait for perfection before getting value.


### PR DESCRIPTION
Fixes #3

This adds a technical article explaining OpenUI's progressive hydration model for streamed model output.

Focus areas:
- why React rendering assumptions break down with token streams
- why stream-friendly structured UI output helps more than waiting for full JSON
- how partial trees become renderable UI
- why fallback boundaries and subtree stability matter
- the real architectural tradeoffs behind progressive rendering

The piece is intentionally implementation-facing rather than broad or promotional.
