### PR TITLE
docs: add article on UI-based vs text-based chatbots

### DIFF
--- a/Articles/UI-Based Chatbots vs Text-Based Chatbots - A Performance Comparison Across Task Completion, Time-on-Task, and User Satisfaction.md
+++ b/Articles/UI-Based Chatbots vs Text-Based Chatbots - A Performance Comparison Across Task Completion, Time-on-Task, and User Satisfaction.md
@@ -1,0 +1,374 @@
+# UI-Based Chatbots vs. Text-Based Chatbots: A Performance Comparison Across Task Completion, Time-on-Task, and User Satisfaction
+
+Most chatbot discussions are still framed the wrong way.
+
+People ask:
+
+- Which model is smarter?
+- Which prompts are better?
+- Which agent framework is more flexible?
+
+Those are useful questions.
+
+They are not the whole product question.
+
+For many real workflows, the bigger question is:
+
+> what kind of interface helps users complete the task faster and with less confusion?
+
+That is where the difference between text-based chatbots and UI-based chatbots becomes meaningful.
+
+This article looks at that difference through three product-facing lenses:
+
+- task completion
+- time-on-task
+- user satisfaction
+
+And it uses OpenUI as the practical path for building the more structured side of that comparison.
+
+## First, Define the Two Surfaces Properly
+
+The comparison gets messy if the categories are vague.
+
+For this article:
+
+### Text-based chatbot
+
+The model mainly returns prose:
+
+- paragraphs
+- bullet points
+- links
+- maybe some markdown
+
+The user extracts meaning and decides what to do next.
+
+### UI-based chatbot
+
+The model returns or drives structured interface elements:
+
+- cards
+- tables
+- forms
+- pickers
+- status badges
+- action buttons
+
+The user interacts with visible state, not just explanation.
+
+This does not mean the UI-based chatbot stops being conversational.
+
+It means the conversation is no longer the only surface.
+
+## Metric 1: Task Completion
+
+Task completion is the cleanest place to start.
+
+A text chatbot may provide the right answer and still fail at the task.
+
+Why?
+
+Because users often need to:
+
+- compare options
+- inspect records
+- select one path
+- confirm an action
+- notice missing data
+- and move to the next step
+
+Plain text makes all of that harder.
+
+For example, if a user asks:
+
+> Which of these three opportunities should I pursue first?
+
+a text-based chatbot might return:
+
+- a paragraph of explanation,
+- a ranked list,
+- a note about risk,
+- and a recommendation.
+
+That sounds helpful.
+
+But the user still has to mentally extract:
+
+- the ranking,
+- the risk,
+- the blockers,
+- the next action,
+- and what exactly to click or approve next.
+
+A UI-based chatbot can instead render:
+
+- three ranked cards,
+- confidence score,
+- risk badge,
+- blockers section,
+- approve / defer / reject buttons.
+
+That usually improves completion because:
+
+- the state is visible,
+- the next action is obvious,
+- and comparison cost drops.
+
+The chatbot is no longer just "answering." It is helping the user finish.
+
+## Metric 2: Time-on-Task
+
+Text is dense. Interfaces can be scannable.
+
+That difference matters more than many teams admit.
+
+Text-based systems often force the user to:
+
+- read everything,
+- parse priorities,
+- remember earlier parts of the answer,
+- and translate prose into action.
+
+That is expensive in time and attention.
+
+A UI-based system can reduce that cost by making key distinctions visual:
+
+- status through color or badges
+- ranking through order
+- urgency through placement
+- next step through buttons
+
+The user does less reconstruction.
+
+That usually means lower time-on-task for structured workflows such as:
+
+- triage
+- approvals
+- support routing
+- task selection
+- checkout/configuration flows
+
+The point is not that text is always slower.
+
+The point is that text becomes inefficient when the user is not just reading, but choosing and acting.
+
+## Metric 3: User Satisfaction
+
+Satisfaction is not just "did the model sound good?"
+
+It is closer to:
+
+- did the system feel easy to use?
+- did the user feel in control?
+- did the result feel trustworthy?
+- did the interface reduce friction or add it?
+
+Text-based chatbots often score well on flexibility but poorly on control when tasks become structured.
+
+Users can ask anything, but they may not feel sure about:
+
+- what the system actually decided
+- what state it is in
+- whether a destructive action is about to happen
+- how to change one part of the result without starting over
+
+UI-based chatbots often improve satisfaction because they make system state inspectable.
+
+Instead of:
+
+- invisible reasoning
+- long text blobs
+- hidden assumptions
+
+the user gets:
+
+- visible objects
+- visible actions
+- visible progress
+
+That tends to reduce uncertainty, which strongly affects perceived quality.
+
+## Where Text-Based Chatbots Still Win
+
+This is not a universal anti-text argument.
+
+Text-based chatbots are still better when:
+
+- the user is exploring an idea
+- the response is mainly explanatory
+- the task has no real branching state
+- the user needs flexible back-and-forth
+
+Examples:
+
+- brainstorming
+- asking conceptual questions
+- requesting summaries
+- discussing tradeoffs
+
+The problem is when teams keep the same text-first surface even after the task becomes obviously structured.
+
+That is where performance drops.
+
+## The Real Breakpoint: When the User Needs to Decide
+
+A useful rule is this:
+
+> if the user needs to inspect, compare, approve, reject, or submit something, text alone usually stops being the best interface.
+
+That is the breakpoint.
+
+Before that point, a text chatbot may be enough.
+
+After that point, the interface should usually become more structured.
+
+This is why UI-based chatbots are especially strong in:
+
+- onboarding flows
+- support flows
+- procurement approval
+- ops triage
+- sales qualification
+- dashboard-like AI surfaces
+- tool-driven agent workflows
+
+All of these need more than explanation.
+
+They need a surface for action.
+
+## What OpenUI Changes
+
+This is where OpenUI becomes relevant.
+
+OpenUI is useful because it lets you build the structured side of the chatbot without hardcoding every possible screen in advance.
+
+That matters for UI-based chatbots because the hard problem is not just:
+
+- making a prettier response
+
+It is:
+
+- giving the system enough structure to render useful UI,
+- while still letting it adapt to the user's context.
+
+OpenUI works well here because it gives you:
+
+- a constrained language for generated UI
+- component-library control
+- streaming-friendly rendering
+- a path from model state to actual interface
+
+In other words:
+
+it makes "UI-based chatbot" something you can build as a system, not just mock up as a demo.
+
+## A Concrete Example
+
+Imagine a chatbot helping a user choose which task to work on next.
+
+### Text-based version
+
+It might say:
+
+> I found three options. The first has the best payout but moderate risk. The second is lower risk but lower value. The third is stale and not recommended. I suggest choosing the first one.
+
+That is understandable.
+
+But it leaves real UX work on the user.
+
+### UI-based version
+
+It could show:
+
+- task card 1: payout, risk, blockers, confidence
+- task card 2: payout, risk, blockers, confidence
+- task card 3: stale warning
+- action row: approve / defer / reject
+
+Same intelligence.
+
+Better task surface.
+
+That difference is exactly what product teams should care about when they ask about chatbot performance.
+
+## Why This Matters for Product Teams
+
+A lot of chatbot evaluations still overvalue answer quality and undervalue interface cost.
+
+But users do not experience intelligence only through words.
+
+They experience it through:
+
+- how quickly they can finish the task
+- how much cognitive effort it takes
+- how clearly they understand the system state
+- how confidently they can act
+
+That means the right evaluation question is not:
+
+> Did the chatbot answer correctly?
+
+It is:
+
+> Did the chatbot help the user complete the task well?
+
+That is a much more demanding standard.
+
+And it is why UI-based chatbots are often the stronger product choice for serious workflows.
+
+## The Tradeoff
+
+UI-based chatbots are not free wins.
+
+They require:
+
+- a component library
+- stricter validation
+- action schemas
+- more design-system discipline
+
+They can also become worse if the generated UI is:
+
+- noisy
+- inconsistent
+- unsafe
+- or too clever for its own good
+
+So the goal is not "replace all chat with UI."
+
+The goal is:
+
+- use text where explanation is enough
+- use structured UI where task completion depends on visible state and action
+
+That is a much better design rule.
+
+## Final Takeaway
+
+Text-based chatbots are strong at explanation.
+
+UI-based chatbots are stronger at structured task completion.
+
+Across the three metrics that matter most in product UX:
+
+- task completion
+- time-on-task
+- user satisfaction
+
+the structured side tends to win whenever the workflow requires:
+
+- comparison
+- approval
+- filtering
+- progression
+- or explicit action
+
+This is why the future of chatbot UX is not just "better text."
+
+It is better surfaces.
+
+And that is the real promise of tools like OpenUI:
+
+not just that the model can answer,
+
+but that the answer can become an interface the user can actually use.


### PR DESCRIPTION
Fixes #9

This adds a product-facing but still developer-grounded article comparing text-based chatbot surfaces with UI-based chatbot surfaces across:
- task completion
- time-on-task
- user satisfaction

It keeps the framing practical and uses OpenUI as the implementation path for structured, reviewable, action-oriented chatbot surfaces rather than as a broad product pitch.
