### PR TITLE
docs: add article on Chakra UI + OpenUI

### DIFF
--- a/Articles/Chakra UI + OpenUI - Building a Design-System-Aware Generative UI App.md
+++ b/Articles/Chakra UI + OpenUI - Building a Design-System-Aware Generative UI App.md
@@ -1,0 +1,385 @@
+# Chakra UI + OpenUI: Building a Design-System-Aware Generative UI App
+
+The fastest way to make generative UI feel fake is to let the model invent a design system.
+
+You have probably seen this already:
+
+- spacing that changes from component to component
+- random button variants
+- cards with inconsistent density
+- tables that ignore the rest of the app
+- generated layouts that technically work but do not feel like your product
+
+That is not a model problem alone.
+
+It is a surface-control problem.
+
+If you want generative UI to feel production-ready, the model needs to generate **inside** your design system, not around it.
+
+This is where Chakra UI and OpenUI fit together nicely:
+
+- **Chakra UI** gives you a mature component system
+- **OpenUI** gives you a structured way to let the model assemble interfaces from that system
+
+This article walks through the practical side of that pairing:
+
+- how to expose a Chakra component library to OpenUI
+- how to constrain what the model can generate
+- how to keep theme-awareness and consistency
+- how to avoid turning your app into a pile of model-generated layout drift
+
+## The Goal Is Not \"More Components\"
+
+A lot of developers approach generative UI as if the model's job is:
+
+- invent a screen,
+- invent components,
+- invent styles,
+- invent interactions.
+
+That is usually the wrong direction for product work.
+
+For a real app, the better goal is:
+
+> let the model compose from approved building blocks.
+
+That means your Chakra setup should already contain the components you actually want reused:
+
+- metric cards
+- alert banners
+- tables
+- filters
+- buttons
+- stat blocks
+- dialog patterns
+
+The model should choose and arrange these, not freestyle the visual system from scratch.
+
+## What OpenUI Adds on Top of Chakra
+
+Chakra alone already solves component reuse.
+
+OpenUI becomes useful when the interface structure itself is generated from intent.
+
+For example, instead of hand-authoring every dashboard or support screen, you can let the system decide:
+
+- should this result be a card list or a table?
+- should this state show a warning banner?
+- should the action row be inline or at the bottom?
+- should this output be compact summary first, then detail drilldown?
+
+That is the generative part.
+
+Chakra gives you the components.  
+OpenUI gives you the structured generation layer.
+
+## Step 1: Define a Narrow Component Surface
+
+The first mistake is exposing too many raw primitives.
+
+If you hand the model every low-level layout piece, it will often produce:
+
+- overly verbose trees
+- inconsistent composition
+- fragile interfaces
+
+A better pattern is to expose mid-level product components.
+
+For example:
+
+```ts
+const components = [
+  "DashboardShell",
+  "MetricCard",
+  "RiskBadge",
+  "TaskTable",
+  "ApprovalActions",
+  "EmptyState",
+]
+```
+
+These can be backed by Chakra internally:
+
+```tsx
+import {
+  Box,
+  Card,
+  CardBody,
+  HStack,
+  Badge,
+  Button,
+  Table,
+  Text,
+} from "@chakra-ui/react"
+
+export function MetricCard({
+  label,
+  value,
+  helperText,
+}: {
+  label: string
+  value: string
+  helperText?: string
+}) {
+  return (
+    <Card>
+      <CardBody>
+        <Text fontSize="sm" color="gray.500">{label}</Text>
+        <Text fontSize="2xl" fontWeight="bold">{value}</Text>
+        {helperText ? <Text fontSize="sm">{helperText}</Text> : null}
+      </CardBody>
+    </Card>
+  )
+}
+
+export function RiskBadge({ level }: { level: "low" | "medium" | "high" }) {
+  const colorScheme =
+    level === "high" ? "red" : level === "medium" ? "orange" : "green"
+
+  return <Badge colorScheme={colorScheme}>{level}</Badge>
+}
+```
+
+This gives the model meaningful building blocks without giving away your visual discipline.
+
+## Step 2: Generate with Constraints
+
+Once your component set exists, the next job is prompt discipline.
+
+The model should know:
+
+- which components are allowed
+- what each component is for
+- what actions are legal
+- what should never appear
+
+For example:
+
+```ts
+import { generatePrompt } from "@openuidev/lang-core"
+
+const prompt = generatePrompt({
+  name: "Chakra Support Dashboard",
+  components: [
+    "DashboardShell",
+    "MetricCard",
+    "RiskBadge",
+    "TaskTable",
+    "ApprovalActions",
+    "EmptyState",
+  ],
+  toolCalls: true,
+  bindings: true,
+  editMode: true,
+  inlineMode: true,
+  preamble:
+    "Use only the provided components. Prefer compact operational dashboards over decorative layout. Never invent new component names.",
+})
+```
+
+This matters more than people think.
+
+If the prompt is vague, the model starts behaving like a speculative designer.
+
+If the prompt is strict, it starts behaving like a layout engine with judgment.
+
+That is much closer to what you want in production.
+
+## Step 3: Keep Theme Awareness in the Components, Not the Prompt
+
+One easy way to make generated UI brittle is to push visual styling decisions into generated output.
+
+For example, if the model has to choose:
+
+- exact spacing values
+- exact colors
+- exact typography scales
+
+you are asking it to recreate your theme every time.
+
+That is a bad deal.
+
+A stronger pattern is:
+
+- keep theme decisions inside Chakra-backed components
+- let the model choose semantic structure only
+
+For example:
+
+```tsx
+export function ApprovalActions({
+  onApprove,
+  onReject,
+  onDefer,
+}: {
+  onApprove: () => void
+  onReject: () => void
+  onDefer: () => void
+}) {
+  return (
+    <HStack spacing={3}>
+      <Button colorScheme="green" onClick={onApprove}>Approve</Button>
+      <Button colorScheme="red" variant="outline" onClick={onReject}>Reject</Button>
+      <Button variant="ghost" onClick={onDefer}>Defer</Button>
+    </HStack>
+  )
+}
+```
+
+The model chooses whether the approval block belongs in the UI.
+
+It does not choose how your approval buttons should look.
+
+That is exactly the right division of responsibility.
+
+## Step 4: Build for Real Use Cases, Not Toy Screens
+
+The Chakra + OpenUI pairing gets interesting when the generated interface has to support:
+
+- support triage
+- internal task review
+- approval workflows
+- anomaly dashboards
+- CRM review panels
+
+Take a task-review example:
+
+```ts
+type CandidateTask = {
+  id: string
+  title: string
+  estimatedValue: number
+  confidence: number
+  risk: "low" | "medium" | "high"
+}
+```
+
+The model does not need to invent a full app.
+
+It needs to map this into:
+
+- metric summary,
+- ranked table,
+- visible risk,
+- explicit action surface.
+
+That is a much more realistic product target than "generate any UI."
+
+## Step 5: Validate the Action Surface
+
+As soon as the generated interface can trigger actions, the stakes go up.
+
+For example:
+
+- approve
+- reject
+- submit
+- defer
+- escalate
+
+Those should not be treated as loose UI strings.
+
+They should resolve into structured payloads:
+
+```ts
+type ReviewAction = {
+  type: "task_decision"
+  taskId: string
+  decision: "approve" | "reject" | "defer"
+}
+```
+
+This is where Chakra helps from the UI side and OpenUI helps from the generation side:
+
+- Chakra ensures consistent, understandable controls
+- OpenUI ensures the model emits a valid structured surface
+
+Then your validator ensures the action is legal before it executes.
+
+That three-part split is what makes generated UI feel safe enough to use.
+
+## What Usually Breaks First
+
+When people try to combine a design system with generative UI, the first failures are predictable.
+
+### 1. The model gets too much surface area
+
+It starts generating layout shapes your product does not actually want.
+
+### 2. The component set is too low-level
+
+You end up with valid Chakra trees that still feel inconsistent because the model is rebuilding larger patterns from raw primitives.
+
+### 3. Theme is treated as generated data
+
+Spacing, color, and typography drift because those choices are not locked inside the components.
+
+### 4. Actions are not schema-checked
+
+The UI looks fine, but emitted actions are malformed or unsafe.
+
+None of these are reasons to avoid the stack.
+
+They are reasons to be strict about what the stack is for.
+
+## A Better Mental Model
+
+Do not think:
+
+> the model generates Chakra UI
+
+Think:
+
+> the model composes from a Chakra-backed product component library through OpenUI constraints
+
+That is much closer to how this should work in real apps.
+
+You are not outsourcing design.
+
+You are outsourcing layout decisions inside a controlled system.
+
+## Where This Stack Fits Best
+
+Chakra + OpenUI works best when:
+
+- you already have a design system mindset
+- you want generated interfaces to feel native to your product
+- you need action-oriented screens, not just pretty responses
+- you want flexibility without losing visual consistency
+
+It is especially good for:
+
+- internal tools
+- dashboards
+- support systems
+- approval surfaces
+- AI copilots inside existing apps
+
+In all of these, the product needs to feel coherent, even when the layout is dynamic.
+
+That is the main value of pairing a real component system with a real generative UI layer.
+
+## Final Takeaway
+
+Generative UI does not become production-ready when the model gets more creative.
+
+It becomes production-ready when the surface becomes more constrained.
+
+That is why Chakra UI + OpenUI is a useful pairing:
+
+- Chakra gives you the visual and interaction discipline
+- OpenUI gives you the structured generation layer
+
+Together, they let you build interfaces that are:
+
+- adaptive,
+- structured,
+- and still recognizably part of your app
+
+That is the real win.
+
+Not "AI made a screen."
+
+But:
+
+> AI generated the right interface from a system you still control.


### PR DESCRIPTION
Fixes #2

This adds a practical implementation-focused article about combining Chakra UI with OpenUI for design-system-aware generative interfaces.

Focus areas:
- exposing a narrow component surface instead of raw primitives
- constraining generation through component vocabulary and prompt rules
- keeping theme awareness inside Chakra-backed components
- validating action surfaces for generated UIs
- using the pairing for real dashboard/support-style app flows rather than toy examples

The article is intentionally written as a product-engineering guide, not a generic introduction.
