### PR TITLE
docs: add generative UI explainer article

### DIFF
--- a/Articles/What Is Generative UI - And Why Text Output Is No Longer Enough.md
+++ b/Articles/What Is Generative UI - And Why Text Output Is No Longer Enough.md
@@ -1,0 +1,336 @@
+# What Is Generative UI? (And Why Text Output Is No Longer Enough)
+
+AI products keep getting smarter.
+
+But many of them still feel stuck inside a text box.
+
+You ask a question.  
+You get a paragraph.  
+Maybe a list.  
+Maybe some Markdown.
+
+That worked for early chatbot workflows because text was the easiest universal output format.
+
+It is now becoming one of the biggest constraints in AI product design.
+
+This is the core idea behind generative UI:
+
+> the model should not only generate words. It should be able to generate the interface the user actually needs.
+
+This article explains what generative UI is, why it matters, and where OpenUI fits in as a concrete implementation path.
+
+## The Problem with Text Output
+
+Text is flexible.
+
+It is also inefficient for many application tasks.
+
+Suppose an AI system returns:
+
+- a comparison of three products
+- a list of candidate tasks
+- a risk review for an approval flow
+- a support triage queue
+- a financial summary
+
+Text can describe all of these.
+
+But description is not the same as interface.
+
+If the user needs to:
+
+- compare,
+- filter,
+- sort,
+- inspect,
+- approve,
+- reject,
+- or submit,
+
+then text becomes a weak surface.
+
+The model may be correct, but the user still has to reconstruct the useful state from prose.
+
+That is the real limitation of text output:
+
+> it is good for explanation, but weak for structured interaction.
+
+## What Generative UI Actually Means
+
+Generative UI is not just "AI makes HTML."
+
+It is a system where the model generates structured interface descriptions that can be turned into real components at runtime.
+
+That means the generated output is closer to:
+
+- cards,
+- tables,
+- forms,
+- charts,
+- buttons,
+- layouts,
+
+than to plain paragraphs.
+
+A useful definition is:
+
+> generative UI is the runtime generation of structured user interfaces from model output, within a constrained component system.
+
+That last part matters.
+
+The goal is not for the model to invent arbitrary interfaces from scratch with no guardrails.
+
+The goal is for the model to compose from allowed building blocks in a way that fits the user's task.
+
+## How It Differs from Adjacent Patterns
+
+Developers often mix up four different things:
+
+### 1. Template filling
+
+The model writes into a pre-built screen.
+
+Example:
+
+- fixed support page,
+- dynamic text in a few slots.
+
+This is useful, but the layout is still static.
+
+### 2. Tool calls or function calling
+
+The model calls a function and the application decides how to show the result.
+
+This is powerful, but the model is not directly shaping the interface.
+
+### 3. JSON UI generation
+
+The model outputs a JSON object that describes UI state.
+
+This gets closer, but JSON is often verbose, brittle under streaming, and not always a great medium for progressive UI generation.
+
+### 4. Generative UI
+
+The model generates an interface description that is meant to become UI at runtime.
+
+This is the real shift:
+
+- the output is not just content,
+- it is an interface contract.
+
+## Why This Matters Now
+
+Text output made sense when AI systems were mostly:
+
+- answer engines,
+- summarizers,
+- or chat copilots.
+
+But AI products increasingly need to support:
+
+- approvals,
+- configuration,
+- task review,
+- support operations,
+- research workflows,
+- dashboards,
+- internal tools.
+
+These are not purely conversational experiences.
+
+They are operational experiences.
+
+And operational experiences usually need more than language.
+
+They need structure.
+
+## A Concrete Example
+
+Imagine a user asks:
+
+> Show me the three highest-value tasks I can do next and let me pick one.
+
+### Text-only output
+
+The model might say:
+
+> I found three promising tasks. The first has the highest expected value but medium risk. The second is lower value but easier to complete. The third looks stale and may not be worth pursuing.
+
+That is readable.
+
+It is not a good interface.
+
+The user still has to:
+
+- map which task is which,
+- compare them mentally,
+- remember the risk levels,
+- figure out the next action.
+
+### Generative UI output
+
+A generative UI system can instead render:
+
+- three ranked task cards,
+- visible payout values,
+- risk badges,
+- blocker lists,
+- approve / defer / reject actions.
+
+Same intelligence.  
+Better surface.
+
+That is the difference between an answer and a usable tool.
+
+## What Developers Still Own
+
+Generative UI does not mean developers stop building interfaces.
+
+It changes what they build.
+
+Instead of hand-authoring every screen variation, developers focus more on:
+
+- component libraries,
+- interface constraints,
+- action schemas,
+- validation rules,
+- renderer behavior,
+- fallback boundaries.
+
+In other words:
+
+you do not give the model total design freedom.
+
+You give it a controlled interface vocabulary and let it compose within that system.
+
+That is why generative UI is not anti-engineering.  
+It is a different layer of engineering.
+
+## Where OpenUI Fits
+
+This is where OpenUI becomes useful.
+
+OpenUI provides a practical stack for generative UI:
+
+- a UI language designed for model output
+- a renderer for turning that output into actual interfaces
+- a component-driven approach so the model works inside constraints
+- support for streaming-friendly rendering
+
+That makes it a concrete implementation path rather than just an idea.
+
+The important thing is not that OpenUI exists as a framework.
+
+The important thing is that it treats interface generation as:
+
+- structured,
+- constrained,
+- and renderable.
+
+That is what real generative UI needs.
+
+## Why Not Just Stick to JSON
+
+This is a natural question.
+
+Why not just have the model emit JSON and build the UI from that?
+
+You can.
+
+And many teams do.
+
+But that comes with tradeoffs:
+
+- JSON is verbose
+- JSON is awkward under streaming
+- partial JSON is often unusable until completion
+- JSON describes state generically, not always interfaces naturally
+
+OpenUI's approach is that the representation should be friendlier to:
+
+- streaming,
+- partial rendering,
+- and UI composition itself.
+
+That is one reason generative UI is becoming its own design space rather than just "LLM + JSON."
+
+## When Generative UI Is the Right Tool
+
+Generative UI is strongest when the user needs:
+
+- structured choices
+- interactive state
+- visible progress
+- task-oriented review
+- runtime adaptation
+
+Examples:
+
+- support copilots
+- internal operations dashboards
+- AI research assistants
+- lead qualification flows
+- incident review tools
+- approval surfaces
+
+It is weaker when the job is mostly:
+
+- freeform explanation
+- brainstorming
+- open-ended discussion
+- short informational response
+
+That means text output is not obsolete.
+
+It just should not be the default for everything.
+
+## The Real Shift in Product Thinking
+
+Generative UI matters because it moves the conversation from:
+
+- "What words should the model say?"
+
+to:
+
+- "What surface does the user need right now?"
+
+That is a bigger shift than it sounds.
+
+Because once you ask the second question, the answer often stops being:
+
+- a paragraph,
+- a bullet list,
+- or a blob of Markdown.
+
+It becomes:
+
+- a review card,
+- a table,
+- a stepper,
+- a form,
+- a dashboard panel,
+- an approval surface.
+
+That is the moment text stops being enough.
+
+## Final Takeaway
+
+Generative UI is not just AI output with nicer styling.
+
+It is a different model of application design:
+
+- the model generates interface structure
+- the renderer turns it into usable UI
+- the developer defines the component system and guardrails
+
+That is why the term matters.
+
+It names a real transition:
+
+from AI systems that only speak,
+
+to AI systems that can present, organize, and structure action.
+
+Text got us through the first wave of AI products.
+
+Generative UI is what the next wave needs.


### PR DESCRIPTION
Fixes #7

This adds a first-principles explainer on generative UI, focused on why text-only AI output stops being enough for structured, action-heavy workflows and how a constrained runtime rendering layer changes the product surface.

Focus areas:
- the limits of text output
- what generative UI actually means
- how it differs from templates, tool calls, and raw JSON UI
- what developers still own in a generative UI system
- where OpenUI fits as the concrete implementation path
