### PR TITLE
docs: add article on token cost tradeoffs

### DIFF
--- a/Articles/The Token Cost of Beautiful AI - OpenUI Lang vs AI SDK vs JSON.md
+++ b/Articles/The Token Cost of Beautiful AI - OpenUI Lang vs AI SDK vs JSON.md
@@ -1,0 +1,200 @@
+# The Token Cost of Beautiful AI: OpenUI Lang vs AI SDK vs JSON
+
+Generative UI is not only a frontend problem.
+
+It is also a token-budget problem.
+
+Every extra character your model must emit becomes:
+
+- latency,
+- cost,
+- and potentially worse streaming behavior.
+
+That means the format used to describe UI matters more than many teams realize.
+
+This article looks at the practical tradeoff between:
+
+- plain JSON UI payloads
+- broader SDK-style response shapes
+- and OpenUI Lang
+
+The central question is simple:
+
+> how much are you paying just to describe the interface?
+
+## Why Token Overhead Matters
+
+In a generative UI system, the model is not only generating text content. It is often generating:
+
+- component names,
+- props,
+- layout structure,
+- action metadata,
+- nested child relationships.
+
+That can get verbose quickly.
+
+If the representation is inefficient, you pay for it in three ways:
+
+### 1. Money
+
+More tokens means more cost.
+
+### 2. Latency
+
+More tokens means more time before the UI is useful.
+
+### 3. Streaming friction
+
+Verbose formats usually degrade the "time to first meaningful UI."
+
+## Why JSON Becomes Expensive
+
+JSON is universal, but it is not cheap.
+
+A JSON UI payload usually burns tokens on:
+
+- braces
+- quotes
+- repeated keys
+- commas
+- nesting overhead
+
+Even before the interface meaning becomes useful, the model spends tokens just maintaining syntax.
+
+That overhead is acceptable for many backend tasks.
+
+It becomes more painful when the output itself is a UI tree.
+
+The model ends up spending too much budget on serialization noise instead of interface meaning.
+
+## Why SDK-Style Payloads Can Drift Even Further
+
+Higher-level SDK response formats can be easier for developers to consume, but they often add even more envelope structure:
+
+- metadata wrappers
+- function-call wrappers
+- tool-call wrappers
+- typed message envelopes
+- schema boilerplate
+
+These are useful for orchestration.
+
+They are not always efficient as a direct UI-generation format.
+
+That is the difference:
+
+- orchestration payloads are optimized for system control
+- UI generation payloads should be optimized for rendering efficiency
+
+Those are not always the same thing.
+
+## Why OpenUI Lang Is Different
+
+OpenUI Lang is useful because it is designed specifically for model-generated UI.
+
+That gives it a different optimization target:
+
+- compact structure
+- stream-friendly representation
+- less syntax overhead than generic JSON
+- better alignment with interface composition
+
+The point is not that JSON is bad.
+
+The point is that:
+
+> if the model's job is to describe UI, then a UI-native representation can be cheaper than a generic data representation.
+
+## What You Actually Pay For
+
+When you compare formats, do not only count raw token totals.
+
+Count:
+
+- time to first meaningful render
+- how early partial output becomes useful
+- how much of the stream is syntax vs actual interface meaning
+
+That is where compact UI representations usually pull ahead.
+
+If a format spends half its early output just becoming valid, the user waits longer even when the model is streaming.
+
+That is hidden latency.
+
+## A Simple Mental Model
+
+Imagine you want the model to generate a task review UI.
+
+The semantic information is:
+
+- task title
+- risk
+- confidence
+- action buttons
+
+Everything else is representation overhead.
+
+If your format requires a long generic envelope around that meaning, you are paying tokens for transport syntax rather than interface utility.
+
+That is the cost most teams underestimate.
+
+## Why This Matters in Real Products
+
+For a prototype, extra tokens may not matter much.
+
+For a product with:
+
+- many requests,
+- large interfaces,
+- streaming UX,
+- and paid inference,
+
+token inefficiency becomes a product problem.
+
+You feel it as:
+
+- slower first render
+- higher per-session cost
+- more variance in output timing
+- poorer user perception of responsiveness
+
+This is why UI format choice is not just an implementation detail.
+
+It is part of product economics.
+
+## When JSON Is Still Fine
+
+JSON is still the right answer when:
+
+- the payload is small
+- the output is mostly data, not UI structure
+- deterministic parsing matters more than token efficiency
+- the rendering step is secondary
+
+So the point is not "always use OpenUI Lang."
+
+The point is:
+
+- use JSON when you are mostly transporting data
+- use a UI-native format when you are mostly generating interface
+
+That is the more useful distinction.
+
+## Final Takeaway
+
+Beautiful AI interfaces are not free.
+
+You pay for them in:
+
+- model output tokens
+- rendering latency
+- and system complexity
+
+The better your UI representation fits the actual job, the less waste you carry.
+
+That is the argument for OpenUI Lang:
+
+not just that it is different,
+
+but that it spends more of the model's output budget on interface meaning and less on generic syntax overhead.


### PR DESCRIPTION
Fixes #4

This adds a practical engineering-cost article comparing OpenUI-style UI generation with JSON and broader SDK-style payloads.

Focus areas:
- token overhead as cost and latency
- hidden syntax overhead in generic formats
- why UI-native representations help streaming UX
- when JSON is still the right answer
