### PR TITLE
docs: add article on OpenUI for voice agents

### DIFF
--- a/Articles/OpenUI for Voice Agents - Pairing LiveKit with Generative UI for Real-Time Visual Feedback.md
+++ b/Articles/OpenUI for Voice Agents - Pairing LiveKit with Generative UI for Real-Time Visual Feedback.md
@@ -1,0 +1,243 @@
+# OpenUI for Voice Agents: Pairing LiveKit with Generative UI for Real-Time Visual Feedback
+
+Voice agents feel magical right up until the user needs to see something.
+
+That breakpoint happens fast.
+
+Audio is great for:
+
+- natural turn-taking,
+- hands-free interaction,
+- quick questions,
+- ambient use cases.
+
+Audio is weak for:
+
+- comparing options,
+- confirming risky actions,
+- showing progress,
+- exposing structured state,
+- recovering from interruptions.
+
+That is why voice agents get much better when they are paired with a visual layer.
+
+And that is where OpenUI becomes useful.
+
+This article is about the practical combination:
+
+- **LiveKit** or a similar real-time voice transport for audio interaction
+- **OpenUI** as the structured visual layer for reviewable, dynamic state
+
+The core idea is simple:
+
+> voice is the conversational surface; generative UI is the state surface.
+
+## Why Voice Alone Breaks Down
+
+Voice interfaces are excellent at intent collection.
+
+They are much worse at persistent inspection.
+
+If a voice agent says:
+
+- "I found three tasks"
+- "the first one is higher value"
+- "the second is safer"
+- "the third looks stale"
+
+the user has to hold that state in working memory.
+
+That is fragile.
+
+The problem gets worse when the interaction includes:
+
+- approvals,
+- choices,
+- retries,
+- partial failures,
+- or long-running workflows.
+
+In those cases, users want to see:
+
+- what the system found,
+- what it is doing now,
+- what they are about to approve,
+- and what changed after their last command.
+
+That is not a voice-only problem. It is an interface problem.
+
+## The Better Split: Audio for Intent, UI for State
+
+A good voice-agent product usually benefits from splitting responsibilities:
+
+- **voice** captures intent and supports natural turn-taking
+- **UI** holds state, progress, options, and actions
+
+That gives you the best of both:
+
+- the speed and ease of spoken interaction
+- the clarity and auditability of visible state
+
+This is especially valuable in workflows like:
+
+- support triage
+- meeting copilots
+- logistics coordination
+- field-service tooling
+- agent approvals
+- task routing
+
+All of them need more than speech.  
+They need reviewable surfaces.
+
+## Where LiveKit Fits
+
+LiveKit is useful on the real-time side because it gives you:
+
+- low-latency voice transport
+- audio streams
+- participant/session state
+- room-level coordination
+
+That solves the transport layer for voice interaction.
+
+But it does not solve the UI layer by itself.
+
+You still need a way to represent:
+
+- interim states,
+- task lists,
+- approval controls,
+- structured summaries,
+- and action payloads.
+
+That is where OpenUI fits naturally.
+
+## Where OpenUI Fits
+
+OpenUI is a strong companion for voice agents because it lets the system render state that would otherwise be awkward in speech alone.
+
+Examples:
+
+- the agent is still researching
+- the agent has narrowed to three options
+- the user must approve one action
+- the agent hit a blocker and needs missing information
+- the system wants to show a status change from `researching` to `ready`
+
+Those are all easier to understand visually than verbally.
+
+Instead of asking the voice agent to keep narrating everything, OpenUI can render:
+
+- cards,
+- tables,
+- badges,
+- step indicators,
+- buttons,
+- confirmation rows.
+
+The result feels much more like a real assistant and much less like a talking log stream.
+
+## A Simple Architecture
+
+The pattern can stay simple:
+
+1. User speaks
+2. Voice transport captures audio
+3. STT / agent pipeline interprets intent
+4. Tools return structured results
+5. Agent updates a visual review state
+6. OpenUI renders the current best interface
+7. User either speaks again or clicks a visible action
+
+That means the user is never trapped inside pure audio memory.
+
+They can see the system's current state while still using voice as the primary control channel.
+
+## The Most Valuable UI Surfaces for Voice Agents
+
+There are five UI surfaces that matter especially for voice:
+
+### 1. Progress
+
+Voice is weak at persistent progress reporting.
+
+The interface can show:
+
+- listening,
+- thinking,
+- verifying,
+- waiting for approval,
+- completed.
+
+### 2. Options
+
+When multiple candidates exist, visual cards beat spoken comparisons almost every time.
+
+### 3. Confirmation
+
+High-risk actions should be seen as well as heard.
+
+### 4. Context recall
+
+If the user is interrupted, the UI preserves state without forcing the system to re-explain everything.
+
+### 5. Corrections
+
+Users can correct a misunderstanding by editing or clicking, not only by re-speaking.
+
+## Why This Is Better Than a Traditional Voice Assistant
+
+Traditional voice assistants usually optimize for:
+
+- command execution,
+- short answers,
+- narrow scope.
+
+Modern voice agents increasingly handle:
+
+- multi-step tasks,
+- cross-tool workflows,
+- partial completion,
+- richer outputs.
+
+Once that happens, pure spoken output becomes an increasingly poor fit.
+
+The user needs a sidecar interface.
+
+OpenUI makes that sidecar interface dynamic and state-aware rather than hardcoded.
+
+## The Real Tradeoff
+
+This pairing is not free.
+
+You now have to manage:
+
+- audio latency
+- visual latency
+- sync between spoken state and rendered state
+- action validation
+- interruption handling
+
+But that complexity buys something important:
+
+the user no longer has to trust invisible agent state.
+
+They can see it.
+
+## Final Takeaway
+
+Voice agents are strongest when speech handles intent and UI handles state.
+
+LiveKit helps with the real-time audio side.
+
+OpenUI helps with the dynamic visual side.
+
+Together, they let you build agents that:
+
+- talk naturally,
+- show progress clearly,
+- expose structured options,
+- and support safer approvals.
+
+That is a much better direction than trying to force every serious workflow through speech alone.


### PR DESCRIPTION
Fixes #6

This adds a practical article about why voice agents benefit from a structured visual layer, and how a LiveKit-style realtime voice stack pairs with OpenUI as the reviewable state surface.

Focus areas:
- where voice-only interaction breaks down
- why progress, options, confirmations, and context recall want UI
- how to split audio for intent and UI for state
- where OpenUI fits as the dynamic rendering layer
