### PR TITLE
docs: add UI vs text chatbot performance article

### DIFF
--- a/Articles/ui-based-vs-text-based-chatbots-performance-comparison.md
+++ b/Articles/ui-based-vs-text-based-chatbots-performance-comparison.md
@@ -1,0 +1,120 @@
+# UI-Based Chatbots vs. Text-Based Chatbots: A Performance Comparison Across Task Completion Rate, Time-on-Task, and User Satisfaction
+
+Text chat made AI products easy to ship. It gave every app the same universal interface: a prompt box, a message stream, and a model that can explain almost anything. That was the right starting point. But once teams move from demos to production workflows, the limits show up quickly. Users do not only need answers; they need to compare options, fill fields, approve steps, inspect evidence, recover from errors, and know what changed.
+
+That is where UI-based chatbots start to outperform plain text. The advantage is not just that cards, tables, forms, and buttons look better. Structured UI changes the measurable behavior of a product: it can raise task completion, reduce time-on-task, and improve satisfaction because the interface carries part of the cognitive load that text otherwise pushes onto the user.
+
+OpenUI is interesting because it treats this as a developer problem, not a design afterthought. Instead of asking a model to dump paragraphs and hoping the frontend can parse intent later, OpenUI lets teams generate interface structures that users can act on immediately.
+
+## 1. Task completion rate: structured actions beat ambiguous instructions
+
+Task completion rate measures whether a user actually finishes the job they came to do. In AI products, this usually breaks down at the handoff between “the assistant explained the next step” and “the user successfully performed it.”
+
+A text-only chatbot often responds with something like:
+
+> “I found three plans. The second is cheaper if you pay annually. You can update the billing address in settings before confirming.”
+
+That is useful, but it leaves the user to translate the answer into action. They must remember the options, navigate elsewhere, find the correct setting, and avoid choosing the wrong plan. Every extra interpretation step creates drop-off.
+
+A UI-based chatbot can instead return a comparison table, highlight the recommended plan, show the billing-address form inline, and expose a clear confirm button. The same model reasoning is present, but the output is now executable. The interface makes the success path explicit.
+
+This matters most for tasks with multiple constraints: travel planning, analytics triage, product configuration, account setup, compliance review, and internal operations. In these domains, users fail less often when the system narrows the next valid actions instead of leaving everything in natural language.
+
+OpenUI’s value is that it gives developers a way to express those next actions as UI, not as prose. A model can generate or select components such as lists, cards, tables, forms, status panels, and call-to-action blocks. That reduces the chance that a user understands the answer but still fails the task.
+
+## 2. Time-on-task: text is flexible, but it is slow for scanning and decisions
+
+Time-on-task is the second place where plain text starts to lose. A conversational paragraph is excellent for explanation, but poor for high-speed comparison. Users do not read generated text the way they inspect a dashboard. They scan headings, numbers, labels, outliers, colors, and positions.
+
+Consider a support assistant that needs to summarize a customer’s account:
+
+- current plan
+- open invoices
+- last three tickets
+- risk score
+- recommended next action
+
+A text answer can include all of this, but the user must visually parse it. A UI answer can place the plan in a badge, invoices in a compact table, tickets in a timeline, risk in a warning card, and the recommendation in a primary action panel. The information density is higher, but the mental effort is lower because the layout tells the user what kind of information each item is.
+
+This is a core reason UI-based agents can shorten workflows. They do not merely say “here is the answer”; they arrange the answer so the next decision is obvious.
+
+The difference becomes sharper when the output changes over time. A text chatbot may say:
+
+> “The campaign is underperforming because CTR dropped while CPA rose.”
+
+A UI-based chatbot can show a before/after metric strip, a small trend chart, and a recommended action button. The user reaches the decision faster because the interface encodes comparison.
+
+OpenUI fits this pattern because it is built around generative UI rather than fixed chatbot bubbles. Teams can use the model for reasoning while still giving users structured, scannable output. In practice, that means less time spent rereading explanations and more time spent acting.
+
+## 3. User satisfaction: confidence rises when the interface shows affordances
+
+User satisfaction is not only about delight. In workflow software, satisfaction often means confidence: “I know what happened, I know what I can do next, and I trust that I will not break something.”
+
+Text-only AI often creates uncertainty. The answer may be correct, but the user has to infer whether it is final, provisional, editable, reversible, or safe. A long response can feel impressive while still leaving the user unsure where to click.
+
+UI-based chatbots improve satisfaction by making affordances visible. A button implies action. A disabled button explains a missing prerequisite. A table implies comparison. A form implies required input. A status pill implies state. These cues are small, but they remove ambiguity.
+
+For example, an AI onboarding assistant can present:
+
+- completed steps
+- missing setup fields
+- optional integrations
+- estimated time remaining
+- a “continue” action
+
+That kind of output feels more trustworthy than a paragraph saying the same thing, because users can see progress and control. The interface turns an abstract conversation into a guided workflow.
+
+OpenUI’s practical advantage is that developers do not need to hard-code every possible assistant response by hand. They can define a UI language and let the model produce structured responses within that language. The result is still dynamic, but it feels more like software than a chat transcript.
+
+## 4. Where text-only chatbots still win
+
+This is not an argument that every AI response needs a full interface. Text remains the best format for:
+
+- open-ended brainstorming
+- narrative explanations
+- first-draft writing
+- subjective reflection
+- short Q&A
+- low-stakes clarification
+
+If the user’s goal is to understand, text is often enough. If the user’s goal is to complete a multi-step task, UI usually helps.
+
+The mistake is treating chat as the default interface for every AI workflow. A good product should decide the output format based on the task. Sometimes the answer should be a paragraph. Sometimes it should be a table, checklist, chart, form, or action card.
+
+Generative UI is not anti-chat. It is what chat becomes when the product needs measurable completion rather than passive explanation.
+
+## 5. A practical measurement model for teams
+
+Teams evaluating UI-based chatbots should avoid vague claims like “users liked it better.” The comparison can be measured with simple product metrics:
+
+1. **Task completion rate** — What percentage of users finish the intended workflow without human support?
+2. **Time-on-task** — How long does it take from first response to successful completion?
+3. **Correction rate** — How often do users ask follow-up questions because the output was unclear?
+4. **Misclick or wrong-action rate** — How often do users choose the wrong next step?
+5. **Satisfaction score** — After completion, how confident did users feel?
+
+A strong experiment is straightforward: give one group a text-only assistant and another group an OpenUI-style assistant for the same task. Keep the model reasoning similar, but change the output format. For workflows involving comparison, form filling, status review, or final confirmation, the UI-based version should have a clear path to outperforming the text-only version.
+
+## 6. Why OpenUI is a developer-side unlock
+
+The hard part is not proving that UI is useful. Product teams already know that interfaces matter. The hard part is making UI generation flexible enough for AI workflows without turning every possible response into a custom frontend ticket.
+
+OpenUI addresses that gap by giving developers a way to move from “model says what to do” to “model renders an interface for doing it.” That is the real unlock. It lets AI products keep the flexibility of language while gaining the usability of structured software.
+
+For developers, this changes the implementation question from:
+
+> “How do I parse a long model response and map it back into UI?”
+
+into:
+
+> “What UI primitives should the model use for this workflow?”
+
+That is a better abstraction. It is easier to test, easier to review, and easier to improve over time.
+
+## Conclusion
+
+Text-based chatbots are excellent for conversation, but many production AI workflows are not just conversations. They are tasks. Tasks need structure, visible state, constrained actions, and fast comparison.
+
+UI-based chatbots can improve task completion by turning recommendations into actions. They can reduce time-on-task by making information scannable. They can raise satisfaction by showing users what is possible, what is missing, and what happens next.
+
+OpenUI matters because it makes this shift practical. It gives teams a path from plain generated text to interactive generated interfaces. For simple questions, text is still enough. For complex work, the better chatbot is no longer just a smarter speaker. It is a usable interface.


### PR DESCRIPTION
Closes #9

## Summary
- Adds a research-backed article comparing UI-based chatbots and text-based chatbots across task completion rate, time-on-task, and user satisfaction.
- Positions OpenUI as the practical developer path from plain generated text to structured, interactive task output.
- Includes a measurement model teams can use for A/B testing UI-based assistant outputs against text-only outputs.

## Validation
- Word count: 1,509 words.
- Private/internal term scan passed.
- `git diff --check` passed.
