### PR TITLE
docs: add living interfaces dashboard article

### DIFF
--- a/Articles/from-static-dashboards-to-living-interfaces.md
+++ b/Articles/from-static-dashboards-to-living-interfaces.md
@@ -1,0 +1,138 @@
+# From Static Dashboards to Living Interfaces: How AI Is Redefining the Way We Display Data
+
+For years, the default answer to "show me the data" has been a dashboard: a fixed canvas, a handful of filters, and charts someone had to anticipate in advance. That model still works for recurring questions. It breaks down when the useful next view depends on the user's intent, the shape of the data, and the conversation that led there.
+
+AI products are exposing that gap. A user does not ask an assistant for "the Q2 revenue dashboard, filtered by segment, with the third tab open." They ask: "Why did enterprise expansion slow down last quarter?" The useful interface for that question might be a cohort table, a variance waterfall, a list of at-risk accounts, a follow-up drilldown, and a short narrative. If the answer is only plain text, the user loses structure. If the answer is only a prebuilt dashboard, the user loses context.
+
+The next step is not prettier charts. It is generated interfaces: UI that is assembled at runtime around the job the user is trying to do.
+
+## The dashboard contract is too rigid
+
+Traditional dashboards assume three things:
+
+1. The important questions are known ahead of time.
+2. The same layout works for most users.
+3. The data shape is stable enough to design around.
+
+Those assumptions are reasonable for board metrics, finance packs, uptime pages, and operational scorecards. They are much weaker for exploratory work.
+
+A product manager investigating activation may need a funnel, a cohort breakdown, a heatmap of drop-off reasons, and snippets from user interviews. A support lead looking at churn risk may need tickets, account metadata, usage deltas, and renewal notes in one view. A developer debugging an incident may need logs, traces, deploy diffs, and a timeline.
+
+The problem is not that dashboards are bad. The problem is that dashboards are authored, while many business questions are discovered.
+
+When the question changes, the interface should be able to change with it.
+
+## Plain text assistants are not enough either
+
+Chat interfaces made data tools more flexible because users could ask follow-up questions without learning a query language. But chat often collapses rich information into paragraphs and bullet lists.
+
+That creates a different failure mode: the model may have the right analysis but the wrong medium.
+
+Consider an assistant response like this:
+
+> Enterprise expansion slowed mostly because accounts with 500+ seats had lower add-on adoption, especially in EMEA. Three accounts explain 41% of the miss. Usage remained stable, but admin-seat activation dropped after the March onboarding change.
+
+That summary is useful. It is not enough. The user probably needs:
+
+- a table of the three accounts,
+- a before/after chart around the onboarding change,
+- a region split,
+- links to underlying evidence,
+- and actions ranked by expected impact.
+
+Text can describe those objects. It cannot replace them.
+
+This is where generative UI becomes practical: the model should not just generate an answer; it should generate the interface needed to inspect the answer.
+
+## Living interfaces: generated, contextual, interactive
+
+A living interface has three properties.
+
+### 1. It is generated from intent
+
+The UI starts from the user's goal, not from a fixed page. If the user asks for variance analysis, the system can render a waterfall and a contributor table. If the user asks for triage, it can render a queue with severity labels and next actions. If the user asks for comparison, it can render side-by-side cards.
+
+The interface is not random decoration. It is selected because it matches the task.
+
+### 2. It preserves interaction
+
+The user can sort, expand, filter, inspect, approve, reject, or drill down. This matters because serious workflows rarely end at the first answer. A good AI interface should let the user test the answer without starting over.
+
+### 3. It carries structure across turns
+
+A generated table from turn one should still be addressable in turn two. If the user says "hide the accounts under $10k ARR" or "turn this into a remediation plan," the system should understand the displayed state and update the interface rather than produce another disconnected block of text.
+
+That is the difference between chat as a transcript and chat as an application surface.
+
+## Why this is hard to build from scratch
+
+A naive implementation looks simple: ask a model for JSON, render components from the JSON, and validate the result. That works for demos. Production systems hit harder questions:
+
+- How much schema detail must be sent to the model each turn?
+- How do you stream partial UI without waiting for one giant JSON object?
+- How do you prevent invalid component trees?
+- How do designers control the look and interaction model?
+- How do engineers keep generated UI debuggable?
+- How do you avoid turning every new component into prompt spaghetti?
+
+The hard part is not rendering a card. The hard part is creating a contract between model output, application state, and real UI components that is expressive without becoming fragile.
+
+OpenUI's relevance is here. It treats UI as a language between AI and interface, not as an afterthought bolted onto a chat box. That distinction matters because generated interfaces need a compact, predictable way to describe structure while still mapping to real components.
+
+## The new stack for data display
+
+The emerging pattern looks like this:
+
+1. **Intent parsing**: understand the user's job and the data objects involved.
+2. **Data retrieval**: query warehouses, APIs, docs, tickets, or product events.
+3. **Reasoning layer**: decide what view best supports the answer.
+4. **UI generation layer**: produce a structured interface description.
+5. **Renderer**: map the interface description to safe, styled components.
+6. **Stateful follow-up**: let the user refine both the analysis and the view.
+
+In that stack, the generated UI layer is not cosmetic. It is the bridge between analysis and action.
+
+A static dashboard asks, "Which prebuilt view do you want?"
+
+A living interface asks, "What are you trying to understand, and what view should exist for that?"
+
+## Where dashboards still win
+
+Generated interfaces will not replace every dashboard. Fixed dashboards remain better when:
+
+- metrics must be audited and consistent,
+- the same view is used by many people,
+- executives need a stable source of truth,
+- regulatory or financial reporting requires locked definitions,
+- or the cost of model involvement is unjustified.
+
+The likely future is hybrid. Stable dashboards become the baseline. AI-generated interfaces become the exploratory and operational layer on top.
+
+A finance team may still keep the canonical revenue dashboard. But when someone asks why net revenue retention moved, the assistant can generate a temporary investigation workspace: segments, cohorts, account lists, notes, and recommended follow-ups.
+
+That temporary workspace may be more valuable than another permanent dashboard tab.
+
+## What teams should evaluate
+
+Teams considering generative UI should ask practical questions, not just admire the demo:
+
+- Can the generated UI be constrained to approved components?
+- Can designers maintain visual quality?
+- Can engineers test and debug outputs?
+- Can the system stream progressively?
+- Can it cite or link to underlying data?
+- Can the interface survive follow-up turns?
+- Does the format reduce prompt and token overhead versus verbose schemas?
+- Can product teams decide which workflows are eligible for generation?
+
+The best implementations will feel less like a chatbot that sometimes shows widgets and more like software that can assemble the right workspace on demand.
+
+## The real shift
+
+Dashboards made data visible. Chat made data askable. Living interfaces make data workable.
+
+That shift is easy to underestimate because early examples look like charts inside chat. The deeper change is that the UI no longer has to be fully predetermined. It can become part of the response: structured, interactive, and fitted to the user's current problem.
+
+The teams that benefit first will not be the ones that replace every screen with AI. They will be the ones that identify the moments where static views fail: investigations, triage, comparisons, audits, planning, and handoffs.
+
+In those moments, the interface should not be a container for the answer. It should be part of the answer.


### PR DESCRIPTION
Closes #8

## Summary
- Adds an article on moving from static dashboards to living, AI-generated interfaces.
- Covers why fixed dashboards break down for exploratory analysis and how OpenUI-style rendering can preserve context, structure, and user actionability.
- Keeps the piece product/developer-focused with practical examples and no unsupported benchmark claims.

## Validation
- Word count checked: 1,364 words.
- `git diff --check` passed.
- Public-copy scan passed for private/internal terms.
