### PR TITLE
docs: add plain text UI failures article

### DIFF
--- a/Articles/plain-text-ui-failures-openui-fixes.md
+++ b/Articles/plain-text-ui-failures-openui-fixes.md
@@ -1,0 +1,217 @@
+# 5 Things That Look Terrible as Plain Text — And How OpenUI Fixes Them
+
+Most AI products still treat the answer box as the final interface. The model
+thinks, the server streams tokens, and the user receives a block of markdown.
+That works for a short explanation. It breaks down the moment the answer
+contains comparisons, progress, decisions, or anything the user is supposed to
+act on.
+
+Plain text is not neutral. It hides hierarchy, makes state hard to scan, and
+pushes interaction back onto the user. A model can explain a pricing plan, a
+debugging trace, or a workflow approval in words, but the user still has to
+mentally reconstruct the UI that should have been there.
+
+OpenUI changes the output contract. Instead of asking the model to describe an
+interface, the product can ask it to generate structured UI: cards, tables,
+forms, timelines, filters, charts, and action surfaces that fit the task. Below
+are five common AI-response scenarios that look weak as plain text and become
+much more useful when rendered as UI.
+
+## 1. Product comparisons
+
+### Before: the wall-of-bullets comparison
+
+A typical chatbot answer to “compare these three tools for a small team” becomes
+a long list:
+
+- Tool A is cheaper but lacks audit logs.
+- Tool B has enterprise controls but costs more.
+- Tool C is easiest to adopt but weak on integrations.
+
+That is readable for three items and five features. It gets painful when the
+user needs to compare pricing, limits, security, integrations, support tiers,
+and migration effort. Markdown tables help, but they are still static text. They
+rarely expose the decision logic: what matters most for this user?
+
+### After: a decision card + weighted comparison table
+
+With OpenUI, the response can render a comparison table with highlighted winners
+per row, a scorecard at the top, and a small “assumption panel” showing what the
+model optimized for.
+
+A better generated interface might include:
+
+- a recommendation card: “Best fit: Tool B if audit logs are mandatory”;
+- a weighted table for price, admin controls, onboarding, integrations, and
+  risk;
+- badges for “dealbreaker,” “nice-to-have,” and “unknown — verify”;
+- an expandable evidence drawer for each claim;
+- a simple selector that lets the user change priorities from “lowest cost” to
+  “lowest migration risk.”
+
+This is not decoration. The user can scan the tradeoff, challenge the
+assumptions, and make a decision faster. The AI is no longer only answering; it
+is shaping the decision surface.
+
+## 2. Setup instructions and onboarding flows
+
+### Before: numbered steps that turn into a checklist in the user’s head
+
+Setup instructions are one of the most common AI outputs:
+
+1. Create an API key.
+2. Add it to `.env`.
+3. Install dependencies.
+4. Run the server.
+5. Test the endpoint.
+
+As text, these steps are easy to generate but easy to abandon. Users lose their
+place, miss prerequisites, or copy commands in the wrong order. Long
+instructions also mix three different things: explanation, commands, and
+verification.
+
+### After: an executable-looking checklist with state and verification
+
+OpenUI can turn the same answer into a setup panel:
+
+- prerequisite cards for Node, Python, Docker, or API access;
+- step cards with commands in copyable blocks;
+- a visible status field for “not started,” “in progress,” and “verified”;
+- expected output snippets under each command;
+- warning callouts for platform-specific traps;
+- a final “done when…” validation box.
+
+Even if the UI is not actually executing commands, the structure changes
+behavior. The user knows what to do next, how to verify it, and where failure
+probably occurred. This is especially useful for developer tools, where the
+difference between “install this” and “install this, then confirm this exact
+output” is the difference between a completed setup and a support ticket.
+
+## 3. Data summaries and analytics
+
+### Before: text that buries the signal
+
+Ask an AI system to summarize sales, usage, or support data and the default
+answer usually looks like:
+
+“Revenue increased by 12%, churn was mostly flat, enterprise leads rose in the
+west region, and mobile activation declined slightly.”
+
+This is concise, but it makes the user do all the visual work. Is 12% large or
+small compared with the previous month? Which region changed most? Is the mobile
+activation decline a warning or noise? Plain text compresses data, but it does
+not give the user a dashboard.
+
+### After: compact cards, deltas, and drill-downs
+
+OpenUI can render the answer as a small analytical view:
+
+- KPI cards for revenue, churn, activation, and pipeline;
+- colored deltas with period comparisons;
+- a ranked table of top movers;
+- a mini trend chart for the metric that changed most;
+- a “watch next” section with two or three investigation prompts;
+- a disclosure panel that shows query scope and missing data.
+
+This kind of generated UI lets the model preserve nuance without forcing a
+spreadsheet into prose. The user can see the main signal first, then inspect the
+supporting rows. For business workflows, that is the difference between
+“interesting summary” and “usable operating view.”
+
+## 4. Debugging traces and error explanations
+
+### Before: a paragraph about what might be wrong
+
+Debugging is where plain text often feels most frustrating. A model might say:
+
+“The error is likely caused by a missing environment variable or a mismatched
+API base URL. Check your `.env` file and confirm the request headers.”
+
+That can be correct and still be hard to use. Debugging is a stateful process:
+symptoms, likely causes, evidence, commands to run, expected results, and next
+branches. A paragraph flattens all of that.
+
+### After: a diagnostic tree
+
+With OpenUI, the model can render a diagnostic tree or troubleshooting board:
+
+- top symptom: `401 Unauthorized on POST /v1/messages`;
+- likely causes ranked by probability;
+- evidence chips showing which log lines support each hypothesis;
+- commands to confirm or reject a cause;
+- branch logic: “if this returns empty, check secret loading; if it returns a
+  key, check provider scope”;
+- a final patch suggestion or config diff.
+
+The generated UI becomes a debugging workspace. The user does not need to reread
+the full response after each test. They can move down the tree, mark checks
+complete, and see the next most likely fix. For agentic developer tools, this is
+also a cleaner handoff between model reasoning and human verification.
+
+## 5. Approval, review, and workflow decisions
+
+### Before: dense summaries with hidden actions
+
+A common enterprise AI use case is “summarize this request and tell me whether
+to approve it.” Plain text might produce:
+
+“The vendor renewal is within budget, but the contract auto-renews for 24 months
+and includes a 15% price increase after year one. Legal should review the
+termination clause.”
+
+This is useful, but it does not match the user’s actual task. The user needs to
+approve, reject, request changes, or route the item. Plain text describes the
+decision; it does not present the decision interface.
+
+### After: review cards with explicit actions
+
+OpenUI can generate a review surface:
+
+- summary card with amount, requester, deadline, and risk level;
+- policy checks with pass/warn/fail states;
+- extracted clauses that triggered warnings;
+- recommended action: “request legal review before approval”;
+- action buttons for approve, reject, ask for changes, or escalate;
+- comment draft generated from the selected action.
+
+This is where generative UI becomes operational. The model is not only producing
+a recommendation; it is rendering the correct workflow around the
+recommendation. That reduces context switching and makes the AI output
+auditable.
+
+## Why this matters for product teams
+
+The biggest benefit of OpenUI is not that AI answers become prettier. It is that
+AI answers can become task-shaped.
+
+Plain text is one universal output format. Real products need many output
+formats: comparison matrices, setup flows, analytics cards, diagnostic trees,
+approval panels, calendars, forms, and dashboards. When teams force every model
+response into markdown, they leave value on the table.
+
+OpenUI gives developers a way to let the interface adapt to the answer. If the
+user asks for a comparison, render a comparison. If the user asks for setup
+help, render a checklist. If the user asks for a decision, render a decision
+panel. The model can still explain, but explanation no longer has to carry the
+whole experience.
+
+There is also a trust benefit. Structured UI can expose assumptions, evidence,
+missing data, and next actions more clearly than prose. That makes model output
+easier to inspect and easier to correct. A user can disagree with a ranking,
+expand the evidence, or change priorities instead of treating the response as a
+blob of text.
+
+## A practical design rule
+
+A useful rule for AI product teams is simple:
+
+If the user would copy the answer into a spreadsheet, checklist, ticket,
+dashboard, or form, the answer probably should not be plain text.
+
+That does not mean every response needs a complex generated interface. Some
+answers should stay short. But when the task involves comparison, state,
+progress, evidence, or action, UI is part of the answer.
+
+OpenUI makes that shift explicit. It turns generative AI from a text box into a
+UI layer that can adapt to what the user is trying to do. That is the real
+upgrade: not more words, but better surfaces for decisions.


### PR DESCRIPTION
Closes #5

## Summary
- Adds a practical article comparing five AI-output cases that work poorly as plain text and better as structured OpenUI surfaces.
- Covers comparisons, debugging traces, approvals, multi-step workflows, and progress/status output.
- Frames OpenUI as a concrete way to turn model output into scannable, actionable UI without requiring the reader to learn OpenUI internals first.

## Validation
- `npx --yes markdownlint-cli "Articles/plain-text-ui-failures-openui-fixes.md"`
- `git diff --check`
