### PR TITLE
Add reproducible OpenUI token benchmark article

### DIFF
--- a/Articles/The Token Cost of Beautiful AI - A Reproducible OpenUI Benchmark.md
+++ b/Articles/The Token Cost of Beautiful AI - A Reproducible OpenUI Benchmark.md
@@ -95,6 +95,8 @@ The current output is:
 | Support triage | 102 | 117 | 123 |
 | **Total** | **300** | **322** | **411** |
 
+![OpenUI token benchmark totals](../assets/openui-token-benchmark-totals.svg)
+
 Across this fixture set, OpenUI Lang is:
 
 - 6.8% smaller than compact JSON,

--- a/Articles/The Token Cost of Beautiful AI - A Reproducible OpenUI Benchmark.md
+++ b/Articles/The Token Cost of Beautiful AI - A Reproducible OpenUI Benchmark.md
@@ -1,0 +1,276 @@
+# The Token Cost of Beautiful AI: A Reproducible OpenUI Benchmark
+
+Generative UI has a simple promise: a model should not be limited to paragraphs
+when the user needs a table, a form, a chart, a card, or a workflow surface.
+
+That promise is attractive. It is also easy to overstate.
+
+The moment an AI product starts asking a model to describe UI, token cost
+becomes part of the product architecture. A text answer might be 120 tokens. A
+small interface description might be 300. A full dashboard with repeated JSON
+keys, action metadata, validation state, and tool-call envelopes can grow much
+faster than the team expects.
+
+So the useful question is not:
+
+> Is OpenUI always cheaper than JSON?
+
+The useful question is:
+
+> What exactly are you paying for when a model returns UI?
+
+I built a small benchmark harness for this article so the answer is inspectable.
+The fixture set compares three ways to represent the same generated interface:
+
+- OpenUI Lang,
+- compact JSON,
+- and an AI SDK-style tool-call envelope.
+
+The numbers are intentionally modest. That is the point. Token cost should be
+measured with fixtures that look like your product, not accepted as a slogan.
+
+## The Three Shapes Being Compared
+
+There are many ways to build generative UI, but most implementations fall into
+one of three response shapes.
+
+The first is a UI-native language. In OpenUI Lang, the model emits a compact
+component-oriented description. The output looks closer to JSX than to a raw
+data tree:
+
+```jsx
+<Panel title="Renewal risk review">
+  <Metric label="At-risk ARR" value="$184k" tone="warning" />
+  <Table columns={["Account","Risk","Reason","Action"]} rows={[
+    ["Northstar","High","No exec sponsor","Schedule call"],
+    ["Luma","Medium","Usage down 23%","Send playbook"]
+  ]} />
+</Panel>
+```
+
+The second is compact JSON. This is the baseline many teams already understand:
+
+```json
+{"component":"Panel","props":{"title":"Renewal risk review","children":[{"component":"Metric","props":{"label":"At-risk ARR","value":"$184k","tone":"warning"}}]}}
+```
+
+The third is a tool-call envelope. This is common when teams build generated UI
+through an orchestration layer. The model does not just return the interface;
+it calls a tool that renders the interface:
+
+```json
+{"toolCallId":"call_renewal_review","toolName":"renderComponent","args":{"component":"Panel","props":{"title":"Renewal risk review"}}}
+```
+
+That envelope is useful. It gives the runtime a declared action boundary. It can
+carry IDs, schemas, and tool metadata. But those wrapper fields are not free.
+
+## Methodology
+
+The benchmark in `benchmarks/token_cost_comparison.py` uses `tiktoken` with the
+`o200k_base` encoding. It compares three equivalent fixtures:
+
+1. A renewal-risk review surface with a metric, table, and actions.
+2. An onboarding checklist with a nested invite form.
+3. A support triage board with a summary, kanban columns, and an escalation
+   button.
+
+The JSON fixtures are minified before counting. That matters. Pretty-printed
+JSON would exaggerate the difference, and teams should not make architecture
+decisions from artificially padded examples.
+
+You can reproduce the counts with:
+
+```bash
+python3 -m pip install tiktoken
+python3 benchmarks/token_cost_comparison.py
+```
+
+The current output is:
+
+| Fixture | OpenUI Lang | Compact JSON | AI SDK-style tool envelope |
+| --- | ---: | ---: | ---: |
+| Renewal risk review | 114 | 123 | 156 |
+| Onboarding checklist | 84 | 82 | 132 |
+| Support triage | 102 | 117 | 123 |
+| **Total** | **300** | **322** | **411** |
+
+Across this fixture set, OpenUI Lang is:
+
+- 6.8% smaller than compact JSON,
+- and 27.0% smaller than the AI SDK-style tool envelope.
+
+The most important part of that result is not the headline number. It is the
+shape of the difference.
+
+## Why Compact JSON Is Harder to Beat Than People Think
+
+If JSON is carefully minified and the payload is small, it can be surprisingly
+competitive. In the onboarding checklist fixture, the compact JSON version is
+slightly smaller than the OpenUI Lang version.
+
+That does not make JSON the winner. It means "JSON is verbose" is an incomplete
+argument.
+
+JSON becomes expensive when the output repeats object keys:
+
+- `component`,
+- `props`,
+- `children`,
+- `type`,
+- `label`,
+- `status`,
+- `action`,
+- `metadata`.
+
+A table represented as an array of objects repeats the same keys on every row. A
+nested component tree repeats `component` and `props` at every level. A tool-call
+format adds `toolName`, `toolCallId`, `args`, and usually more schema metadata
+around the actual UI.
+
+OpenUI Lang is cheaper when the same structure can be expressed positionally or
+as component syntax. Tables can use arrays. Components do not need repeated
+`component` and `props` keys. The model output can be closer to the thing being
+rendered.
+
+But if your JSON is already compact, flat, and sparse, the savings may be
+modest. That is a feature of an honest benchmark, not a problem for OpenUI.
+
+## The Bigger Cost Is the Runtime Contract
+
+Token count is only one cost.
+
+Raw JSON still leaves the application with a question: what does this JSON mean?
+The answer usually becomes a private schema, a renderer, validation rules, error
+handling, and custom action mapping. That work can be fine for one product. It
+becomes expensive when every team invents a different UI description format.
+
+AI SDK-style tool calls solve a different problem. They make the model's action
+boundary explicit. That is useful for orchestration, logging, and safety. The
+tradeoff is that the UI description sits inside a wrapper that may not be
+optimized for visual output.
+
+OpenUI's bet is that generated interfaces deserve their own language and
+renderer. The token savings matter, but the larger value is the contract:
+
+- the model emits a constrained UI description,
+- the host app owns the component library,
+- the renderer turns the description into real React components,
+- actions still flow through application-owned handlers,
+- and the output can stream before the whole response is complete.
+
+That contract is what makes the token cost easier to reason about.
+
+## Cost Projection
+
+Small savings become meaningful at scale, especially when every assistant turn
+can produce UI.
+
+Using the benchmark totals:
+
+- compact JSON costs 322 output tokens per generated UI,
+- the AI SDK-style envelope costs 411 output tokens,
+- OpenUI Lang costs 300 output tokens.
+
+At one million generated UI responses, OpenUI saves 22 million output tokens
+against compact JSON in this fixture set. Against the tool-call envelope, it
+saves 111 million output tokens.
+
+The dollar value depends on the model. The architecture point does not. If the
+product emits generated UI constantly, the response representation becomes a
+recurring infrastructure cost.
+
+Teams should run this math with their own fixtures:
+
+```txt
+monthly_saved_tokens =
+  monthly_ui_generations * (baseline_tokens - openui_tokens)
+```
+
+If the answer is small, choose based on developer experience and safety. If the
+answer is large, the response language deserves the same attention as caching,
+streaming, and model selection.
+
+## Streaming Changes the Evaluation
+
+Token count is not the whole performance story.
+
+A JSON object often needs enough structure to be complete before the app can
+parse and render it safely. A tool-call envelope may need the full tool call
+before the renderer knows what to do. UI-native formats can be designed around
+incremental rendering: components arrive, partial trees stabilize, and the app
+can show useful state before the final token lands.
+
+That does not mean every OpenUI response is magically instant. The app still
+needs guardrails, error boundaries, component validation, and action validation.
+But the format is aligned with the thing users actually see.
+
+For users, that can matter more than the raw token count. A 300-token response
+that starts rendering early can feel faster than a 250-token response that
+renders only after validation succeeds.
+
+## When Each Approach Wins
+
+Use compact JSON when the UI is simple, internal, and tightly controlled. If the
+product needs one or two generated cards, a custom JSON schema may be enough.
+
+Use tool-call envelopes when orchestration is the main problem. If the model is
+choosing among many tools and UI rendering is one side effect among several,
+the extra wrapper fields may be worth the clarity.
+
+Use OpenUI when the generated interface is the product experience. If the user
+is expected to inspect, compare, approve, edit, or act on the response, a
+UI-native representation gives the model a better output target and gives the
+application a clearer rendering contract.
+
+The strongest case for OpenUI is not "JSON bad." It is:
+
+> Generated UI should have a first-class interface language, because UI is not
+> just data.
+
+## What to Benchmark Before Choosing
+
+Before adopting any generated UI format, build fixtures from real product tasks.
+Do not benchmark toy buttons.
+
+Use at least these cases:
+
+- a dense table with repeated rows,
+- a form with validation and disabled states,
+- a dashboard with metrics, charts, and actions,
+- a review workflow with confidence and evidence,
+- and a long-running task state with progress, errors, and recovery actions.
+
+Then measure:
+
+- output tokens,
+- time to first visible UI,
+- parse and validation failure rate,
+- number of renderer fallbacks,
+- model repair turns,
+- and the complexity of action handling.
+
+That last item is easy to ignore. It is also where many generated UI prototypes
+become production liabilities. A cheap response that makes action validation
+ambiguous is not actually cheap.
+
+## The Takeaway
+
+OpenUI Lang can reduce token cost, especially compared with tool-call wrappers
+or verbose JSON trees. In the reproducible fixture set for this article, it
+saved 27.0% against an AI SDK-style envelope and 6.8% against compact JSON.
+
+The second number is deliberately sober. Compact JSON is a real baseline, not a
+straw man.
+
+But token count is only the visible part of the bill. The deeper cost is the
+interface contract: how reliably a model can describe UI, how safely an app can
+render it, and how quickly a user can act on it.
+
+For teams building AI products where the answer often needs to become an
+interface, OpenUI is worth evaluating because it treats generated UI as a
+runtime contract, not a blob of data pretending to be one.
+
+That is what beautiful AI actually costs: tokens, yes, but also structure,
+validation, streaming behavior, and the discipline to make the model compose
+interfaces the product can trust.

--- a/assets/openui-token-benchmark-totals.svg
+++ b/assets/openui-token-benchmark-totals.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">OpenUI Token Benchmark Totals</title>
+  <desc id="desc">A bar chart comparing total output tokens for OpenUI Lang, compact JSON, and an AI SDK style tool envelope across three equivalent UI fixtures.</desc>
+  <rect width="1280" height="720" fill="#f8f6f1"/>
+  <rect x="70" y="58" width="1140" height="604" rx="28" fill="#fffdf8" stroke="#26231d" stroke-width="3"/>
+  <text x="112" y="122" font-family="Inter, Arial, sans-serif" font-size="38" font-weight="800" fill="#26231d">Measured output tokens across the fixture set</text>
+  <text x="112" y="158" font-family="Inter, Arial, sans-serif" font-size="18" fill="#5b5750">Three equivalent generated UI surfaces counted with tiktoken o200k_base.</text>
+
+  <line x1="190" y1="548" x2="1090" y2="548" stroke="#26231d" stroke-width="3"/>
+  <line x1="190" y1="220" x2="190" y2="548" stroke="#26231d" stroke-width="3"/>
+
+  <g stroke="#d8d0c3" stroke-width="2">
+    <line x1="190" y1="468" x2="1090" y2="468"/>
+    <line x1="190" y1="388" x2="1090" y2="388"/>
+    <line x1="190" y1="308" x2="1090" y2="308"/>
+    <line x1="190" y1="228" x2="1090" y2="228"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="14" fill="#6c675f">
+    <text x="132" y="553">0</text>
+    <text x="121" y="473">100</text>
+    <text x="121" y="393">200</text>
+    <text x="121" y="313">300</text>
+    <text x="121" y="233">400</text>
+  </g>
+
+  <g>
+    <rect x="280" y="308" width="150" height="240" rx="12" fill="#2f6fb3"/>
+    <text x="316" y="290" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="800" fill="#173b63">300</text>
+    <text x="276" y="596" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800" fill="#26231d">OpenUI Lang</text>
+    <text x="298" y="624" font-family="Inter, Arial, sans-serif" font-size="14" fill="#5b5750">baseline</text>
+  </g>
+
+  <g>
+    <rect x="565" y="290" width="150" height="258" rx="12" fill="#319465"/>
+    <text x="600" y="272" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="800" fill="#1f5a3d">322</text>
+    <text x="563" y="596" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800" fill="#26231d">Compact JSON</text>
+    <text x="572" y="624" font-family="Inter, Arial, sans-serif" font-size="14" fill="#5b5750">+22 tokens</text>
+  </g>
+
+  <g>
+    <rect x="850" y="219" width="150" height="329" rx="12" fill="#a35f25"/>
+    <text x="885" y="201" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="800" fill="#683812">411</text>
+    <text x="816" y="596" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800" fill="#26231d">Tool-call envelope</text>
+    <text x="856" y="624" font-family="Inter, Arial, sans-serif" font-size="14" fill="#5b5750">+111 tokens</text>
+  </g>
+
+  <rect x="264" y="666" width="752" height="32" rx="16" fill="#26231d"/>
+  <text x="296" y="688" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#fffdf8">OpenUI saves 6.8% vs compact JSON and 27.0% vs the tool-call envelope in this benchmark.</text>
+</svg>

--- a/benchmarks/token_cost_comparison.py
+++ b/benchmarks/token_cost_comparison.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Reproducible token-count fixtures for the OpenUI token-cost article.
+
+Run with:
+    python3 -m pip install tiktoken
+    python3 benchmarks/token_cost_comparison.py
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from dataclasses import dataclass
+
+warnings.filterwarnings("ignore", category=Warning, module="urllib3")
+
+import tiktoken
+
+
+@dataclass(frozen=True)
+class Fixture:
+    name: str
+    openui_lang: str
+    json_payload: dict
+    ai_sdk_payload: dict
+
+
+FIXTURES = [
+    Fixture(
+        name="Renewal risk review",
+        openui_lang="""
+<Panel title="Renewal risk review">
+  <Metric label="At-risk ARR" value="$184k" tone="warning" />
+  <Table columns={["Account","Risk","Reason","Action"]} rows={[
+    ["Northstar","High","No exec sponsor","Schedule call"],
+    ["Luma","Medium","Usage down 23%","Send playbook"],
+    ["Atlas","Low","Expansion open","Create quote"]
+  ]} />
+  <Actions items={["Assign CSM","Export CSV","Create renewal plan"]} />
+</Panel>
+""",
+        json_payload={
+            "component": "Panel",
+            "props": {
+                "title": "Renewal risk review",
+                "children": [
+                    {
+                        "component": "Metric",
+                        "props": {
+                            "label": "At-risk ARR",
+                            "value": "$184k",
+                            "tone": "warning",
+                        },
+                    },
+                    {
+                        "component": "Table",
+                        "props": {
+                            "columns": ["Account", "Risk", "Reason", "Action"],
+                            "rows": [
+                                ["Northstar", "High", "No exec sponsor", "Schedule call"],
+                                ["Luma", "Medium", "Usage down 23%", "Send playbook"],
+                                ["Atlas", "Low", "Expansion open", "Create quote"],
+                            ],
+                        },
+                    },
+                    {
+                        "component": "Actions",
+                        "props": {
+                            "items": [
+                                "Assign CSM",
+                                "Export CSV",
+                                "Create renewal plan",
+                            ]
+                        },
+                    },
+                ],
+            },
+        },
+        ai_sdk_payload={
+            "toolCallId": "call_renewal_review",
+            "toolName": "renderComponent",
+            "args": {
+                "component": "Panel",
+                "props": {
+                    "title": "Renewal risk review",
+                    "blocks": [
+                        {
+                            "type": "metric",
+                            "label": "At-risk ARR",
+                            "value": "$184k",
+                            "tone": "warning",
+                        },
+                        {
+                            "type": "table",
+                            "columns": ["Account", "Risk", "Reason", "Action"],
+                            "rows": [
+                                {
+                                    "account": "Northstar",
+                                    "risk": "High",
+                                    "reason": "No exec sponsor",
+                                    "action": "Schedule call",
+                                },
+                                {
+                                    "account": "Luma",
+                                    "risk": "Medium",
+                                    "reason": "Usage down 23%",
+                                    "action": "Send playbook",
+                                },
+                                {
+                                    "account": "Atlas",
+                                    "risk": "Low",
+                                    "reason": "Expansion open",
+                                    "action": "Create quote",
+                                },
+                            ],
+                        },
+                        {
+                            "type": "actions",
+                            "items": [
+                                "Assign CSM",
+                                "Export CSV",
+                                "Create renewal plan",
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    ),
+    Fixture(
+        name="Onboarding checklist",
+        openui_lang="""
+<Stepper title="Workspace setup" current={2}>
+  <Step label="Connect data source" status="done" />
+  <Step label="Invite reviewers" status="active">
+    <Form fields={["Reviewer email","Role","Due date"]} submit="Send invite" />
+  </Step>
+  <Step label="Publish workflow" status="blocked" note="Needs one reviewer" />
+</Stepper>
+""",
+        json_payload={
+            "component": "Stepper",
+            "props": {
+                "title": "Workspace setup",
+                "current": 2,
+                "steps": [
+                    {"label": "Connect data source", "status": "done"},
+                    {
+                        "label": "Invite reviewers",
+                        "status": "active",
+                        "children": [
+                            {
+                                "component": "Form",
+                                "props": {
+                                    "fields": [
+                                        "Reviewer email",
+                                        "Role",
+                                        "Due date",
+                                    ],
+                                    "submit": "Send invite",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "label": "Publish workflow",
+                        "status": "blocked",
+                        "note": "Needs one reviewer",
+                    },
+                ],
+            },
+        },
+        ai_sdk_payload={
+            "toolCallId": "call_workspace_setup",
+            "toolName": "renderComponent",
+            "args": {
+                "component": "Stepper",
+                "props": {
+                    "title": "Workspace setup",
+                    "current": 2,
+                    "steps": [
+                        {
+                            "id": "connect_data_source",
+                            "label": "Connect data source",
+                            "status": "done",
+                        },
+                        {
+                            "id": "invite_reviewers",
+                            "label": "Invite reviewers",
+                            "status": "active",
+                            "form": {
+                                "fields": [
+                                    {"name": "reviewer_email", "label": "Reviewer email"},
+                                    {"name": "role", "label": "Role"},
+                                    {"name": "due_date", "label": "Due date"},
+                                ],
+                                "submitLabel": "Send invite",
+                            },
+                        },
+                        {
+                            "id": "publish_workflow",
+                            "label": "Publish workflow",
+                            "status": "blocked",
+                            "note": "Needs one reviewer",
+                        },
+                    ],
+                },
+            },
+        },
+    ),
+    Fixture(
+        name="Support triage",
+        openui_lang="""
+<TriageBoard title="Support queue">
+  <Summary text="9 tickets need action; 3 are billing blockers." />
+  <Kanban columns={[
+    ["Urgent", ["Refund failed", "Invoice locked", "Enterprise outage"]],
+    ["Waiting", ["Need logs", "Customer replied"]],
+    ["Done", ["Password reset", "Plan changed"]]
+  ]} />
+  <Button action="escalate_billing" label="Escalate billing blockers" />
+</TriageBoard>
+""",
+        json_payload={
+            "component": "TriageBoard",
+            "props": {
+                "title": "Support queue",
+                "children": [
+                    {
+                        "component": "Summary",
+                        "props": {
+                            "text": "9 tickets need action; 3 are billing blockers."
+                        },
+                    },
+                    {
+                        "component": "Kanban",
+                        "props": {
+                            "columns": [
+                                {
+                                    "title": "Urgent",
+                                    "cards": [
+                                        "Refund failed",
+                                        "Invoice locked",
+                                        "Enterprise outage",
+                                    ],
+                                },
+                                {
+                                    "title": "Waiting",
+                                    "cards": ["Need logs", "Customer replied"],
+                                },
+                                {
+                                    "title": "Done",
+                                    "cards": ["Password reset", "Plan changed"],
+                                },
+                            ]
+                        },
+                    },
+                    {
+                        "component": "Button",
+                        "props": {
+                            "action": "escalate_billing",
+                            "label": "Escalate billing blockers",
+                        },
+                    },
+                ],
+            },
+        },
+        ai_sdk_payload={
+            "toolCallId": "call_support_triage",
+            "toolName": "renderComponent",
+            "args": {
+                "component": "TriageBoard",
+                "props": {
+                    "title": "Support queue",
+                    "summary": "9 tickets need action; 3 are billing blockers.",
+                    "columns": [
+                        {
+                            "id": "urgent",
+                            "title": "Urgent",
+                            "cards": [
+                                "Refund failed",
+                                "Invoice locked",
+                                "Enterprise outage",
+                            ],
+                        },
+                        {
+                            "id": "waiting",
+                            "title": "Waiting",
+                            "cards": ["Need logs", "Customer replied"],
+                        },
+                        {
+                            "id": "done",
+                            "title": "Done",
+                            "cards": ["Password reset", "Plan changed"],
+                        },
+                    ],
+                    "primaryAction": {
+                        "action": "escalate_billing",
+                        "label": "Escalate billing blockers",
+                    },
+                },
+            },
+        },
+    ),
+]
+
+
+def compact_json(payload: dict) -> str:
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+
+def count_tokens(encoding: tiktoken.Encoding, value: str) -> int:
+    return len(encoding.encode(value.strip()))
+
+
+def main() -> None:
+    encoding = tiktoken.get_encoding("o200k_base")
+    rows = []
+
+    for fixture in FIXTURES:
+        openui_tokens = count_tokens(encoding, fixture.openui_lang)
+        json_tokens = count_tokens(encoding, compact_json(fixture.json_payload))
+        ai_sdk_tokens = count_tokens(encoding, compact_json(fixture.ai_sdk_payload))
+        rows.append((fixture.name, openui_tokens, json_tokens, ai_sdk_tokens))
+
+    print("| Fixture | OpenUI Lang | Compact JSON | AI SDK-style tool envelope |")
+    print("| --- | ---: | ---: | ---: |")
+    for row in rows:
+        print(f"| {row[0]} | {row[1]} | {row[2]} | {row[3]} |")
+
+    openui_total = sum(row[1] for row in rows)
+    json_total = sum(row[2] for row in rows)
+    ai_sdk_total = sum(row[3] for row in rows)
+    print(f"| **Total** | **{openui_total}** | **{json_total}** | **{ai_sdk_total}** |")
+    print()
+    print("Savings vs compact JSON: {:.1%}".format(1 - openui_total / json_total))
+    print("Savings vs AI SDK-style envelope: {:.1%}".format(1 - openui_total / ai_sdk_total))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a benchmark-backed article for the token-cost topic with a more reproducible angle than a pure comparison essay.
- Adds `benchmarks/token_cost_comparison.py`, a small `tiktoken` harness that compares OpenUI Lang, compact JSON, and an AI SDK-style tool envelope across three equivalent generated UI fixtures.
- Keeps the article intentionally sober: OpenUI saves 27.0% vs the tool envelope in these fixtures and 6.8% vs carefully compacted JSON, then explains why the runtime contract matters beyond headline token savings.

For #4

## Benchmark output

```txt
| Fixture | OpenUI Lang | Compact JSON | AI SDK-style tool envelope |
| --- | ---: | ---: | ---: |
| Renewal risk review | 114 | 123 | 156 |
| Onboarding checklist | 84 | 82 | 132 |
| Support triage | 102 | 117 | 123 |
| **Total** | **300** | **322** | **411** |

Savings vs compact JSON: 6.8%
Savings vs AI SDK-style envelope: 27.0%
```

## Validation

- `python3 benchmarks/token_cost_comparison.py`
- `python3 -m py_compile benchmarks/token_cost_comparison.py`
- `git diff --check`
- `npx --yes markdownlint-cli --disable MD013 -- "Articles/The Token Cost of Beautiful AI - A Reproducible OpenUI Benchmark.md"`

AI-assisted drafting and editing were used for this contribution.
