### PR TITLE
Add article: Five AI outputs that look terrible as plain text

### DIFF
--- a/Articles/Five AI Answers That Should Be Workspaces Not Paragraphs.md
+++ b/Articles/Five AI Answers That Should Be Workspaces Not Paragraphs.md
@@ -1,4 +1,4 @@
-# Five AI Answers That Should Be Workspaces, Not Paragraphs
+# Five AI Outputs That Look Terrible as Plain Text
 
 Plain text is a good format for explanation. It is a bad format for work.
 
@@ -15,6 +15,24 @@ status blocks, and action buttons. OpenUI is one way to make that possible
 without letting the model invent arbitrary frontend code. The app still owns the
 component library, validation rules, permissions, and action handlers. The model
 chooses how to arrange those pieces for the current task.
+
+That is the important part of how OpenUI fixes the problem. The model should
+not return a block of React code or a blob of arbitrary JSON and hope the app
+trusts it. The product exposes a component vocabulary, then the model responds
+with a structured interface made from those allowed pieces. A conceptual output
+for a review answer might look like this:
+
+```text
+ReviewWorkspace
+  SummaryStrip: high=2, medium=4, low=3
+  FindingsTable: rows=[...], sortableBy=[severity, owner, dueDate]
+  EvidencePanel: selectedFindingId="migration-backfill-counts"
+  DecisionActions: allowed=["request_changes", "mark_ready"]
+```
+
+The exact component names belong to the application, not the model. OpenUI's
+role is to let the answer become a renderable, constrained interface instead of
+another paragraph the user has to translate back into state.
 
 Here are five common AI answers that look worse as plain text than they do as
 small, task-specific workspaces.
@@ -141,38 +159,40 @@ reason, amount, and return status, but it cannot invent a hidden "approve refund
 permission. The renderer turns the model output into real UI, and the app turns
 the submitted form into a normal, auditable action.
 
-## 4. Multi-Step Guidance That Needs Progress
+## 4. Migration Reviews That Need Progress
 
-Step-by-step answers are another place where text looks organized but behaves
-poorly.
+Step-by-step operational answers are another place where text looks organized
+but behaves poorly.
 
-Consider a setup assistant for configuring an analytics integration:
+Consider an assistant reviewing a database migration dry run:
 
 ```text
-1. Create an API key.
-2. Add the tracking script.
-3. Configure allowed domains.
-4. Send a test event.
-5. Verify the event in the dashboard.
+1. Run the migration in dry-run mode.
+2. Compare source and target row counts.
+3. Check foreign-key violations.
+4. Verify billing totals before and after the backfill.
+5. Prepare rollback commands.
 ```
 
 The list is clear, but it has no memory. It cannot show which steps are done,
 which ones failed, which one is blocked by permissions, or where the user should
-resume tomorrow.
+resume tomorrow. It also hides the most important review question: is this
+migration safe to promote, or is it still blocked?
 
 The useful version is a progress workspace:
 
 - A stepper with current state.
-- A checklist for prerequisites.
-- Inline code snippets for the selected framework.
-- Status cards for tests that passed or failed.
-- A retry action for the test event.
-- A final verification panel.
+- A checklist for required preflight checks.
+- Row-count and total-difference cards.
+- Status blocks for passed, failed, and skipped checks.
+- A rollback command panel.
+- A final decision panel that can say "blocked", "needs rerun", or "ready for
+  review".
 
 The assistant can still explain what each step means, but the workflow state
 belongs on screen. If the user completes step two, the interface should change.
-If step four fails, the error should attach to step four, not appear as a new
-paragraph below the list.
+If the billing-total check fails, the error should attach to that check, not
+appear as a new paragraph below the list.
 
 This is especially important for AI agents because they often operate across
 time. A text transcript is a weak project memory. A generated stepper or task

--- a/Articles/Five AI Answers That Should Be Workspaces Not Paragraphs.md
+++ b/Articles/Five AI Answers That Should Be Workspaces Not Paragraphs.md
@@ -1,0 +1,244 @@
+# Five AI Answers That Should Be Workspaces, Not Paragraphs
+
+Plain text is a good format for explanation. It is a bad format for work.
+
+That distinction matters because most AI products still treat every answer as a
+message. The model can identify options, compare tradeoffs, gather inputs, rank
+risks, and suggest next actions, but the result is usually compressed into a
+paragraph, a numbered list, or a Markdown table. The user then has to rebuild
+the interface in their head.
+
+Generative UI changes the shape of that handoff. Instead of asking the model to
+describe the work surface, the application can let the model assemble an
+approved set of components: tables, cards, timelines, forms, review panels,
+status blocks, and action buttons. OpenUI is one way to make that possible
+without letting the model invent arbitrary frontend code. The app still owns the
+component library, validation rules, permissions, and action handlers. The model
+chooses how to arrange those pieces for the current task.
+
+Here are five common AI answers that look worse as plain text than they do as
+small, task-specific workspaces.
+
+## 1. Comparisons That Need Inspection
+
+Plain text comparison is deceptively readable. It looks fine until the user has
+to decide.
+
+Imagine asking an assistant to compare three database providers for a small SaaS
+product. A text answer might say:
+
+```text
+Supabase is strong if you want Postgres, auth, and storage in one platform.
+Neon is strong if you want serverless Postgres with branching. PlanetScale is
+strong if you prefer MySQL and horizontal scaling.
+```
+
+That is useful as commentary, but weak as a decision surface. The user still has
+to track pricing, migration effort, auth support, backup behavior, latency
+tradeoffs, and risks across all three choices. A Markdown table helps, but it is
+still passive. The user cannot filter by must-have criteria, mark unknowns, or
+turn one row into the selected path.
+
+An OpenUI-style answer can render the comparison as a workspace:
+
+- A side-by-side card for each option.
+- A criteria table with columns for cost, lock-in, operational burden, and
+  migration risk.
+- Tags for "strong fit", "needs validation", and "not suitable".
+- A short notes panel explaining the top tradeoff.
+- A "shortlist this" action that updates application state instead of sending
+  another chat message.
+
+The difference is not visual polish. It is that the structure of the decision is
+preserved. The user can scan the same dimensions across all options and take the
+next step without translating prose back into state.
+
+In OpenUI terms, the model should not emit raw JSX or arbitrary CSS. It should
+choose from approved components such as `ComparisonGrid`, `CriteriaTable`,
+`TradeoffCard`, and `DecisionAction`. The application decides what those
+components mean and what actions are allowed. The generated UI is flexible, but
+the product boundary stays fixed.
+
+## 2. Data Summaries That Need Sorting
+
+AI is often asked to summarize operational data: sales by region, support ticket
+volume, release blockers, renewal risk, user feedback, invoice exceptions. Text
+is the worst place to put that kind of answer when the next question is obvious:
+"Which rows matter first?"
+
+A text answer might read:
+
+```text
+There are 18 high-priority support tickets. Most are related to billing,
+followed by login issues. Three enterprise customers are affected. The oldest
+ticket has been open for 41 hours.
+```
+
+That paragraph tells the truth, but it hides the work. A support lead still
+needs to know which tickets are oldest, which customers are highest value, which
+issues have owners, and which ones can be batched into the same fix.
+
+A generated workspace can show:
+
+- A summary strip with counts by severity.
+- A sortable table of tickets.
+- Customer impact tags.
+- Owner and SLA columns.
+- A grouped view by root cause.
+- A review drawer for the selected ticket.
+
+The assistant can still explain the pattern, but the explanation sits beside
+the data instead of replacing it. The user does not need to ask follow-up
+questions just to recover columns that should have been visible from the start.
+
+This is where generative UI becomes less about "prettier chat" and more about
+preserving affordances. Rows should remain rows. Severity should remain a badge.
+Dates should remain sortable. Actions should remain explicit. Plain text flattens
+all of that into a single stream.
+
+OpenUI is useful here because the app can provide a constrained data-table
+component instead of asking the model to draw a table in Markdown. The model can
+decide which fields are important for this answer, but the renderer still
+controls how sorting, selection, empty states, and action buttons behave.
+
+## 3. Forms That Need Validation
+
+Chat is a clumsy form engine.
+
+If a user asks an AI assistant to help create a refund request, the assistant
+might ask for missing information one message at a time:
+
+```text
+Please provide the order ID, refund reason, amount, customer email, and whether
+the product has been returned.
+```
+
+That feels natural for one field. It becomes painful for five. The user cannot
+see what is complete, what is missing, what format is expected, or which value
+failed validation. If the assistant later says "the order ID looks invalid", the
+user has to scroll back and repair the conversation.
+
+The better interface is a form:
+
+- Required fields are visible immediately.
+- The model can prefill values it already inferred.
+- Invalid fields can be marked in place.
+- Optional fields can stay collapsed.
+- The submit button can remain disabled until validation passes.
+- The final action can require explicit user confirmation.
+
+This does not mean the model is trusted to execute the refund. It means the
+model helps assemble the request surface. The application still validates the
+payload, checks permissions, and owns the final action.
+
+That boundary is important. A generative UI form should not be a shortcut around
+business rules. It should be a better way to collect and review the state those
+rules already require.
+
+With OpenUI, the product can expose a `RefundRequestForm` or a smaller set of
+approved field components. The model can decide that this task needs order ID,
+reason, amount, and return status, but it cannot invent a hidden "approve refund"
+permission. The renderer turns the model output into real UI, and the app turns
+the submitted form into a normal, auditable action.
+
+## 4. Multi-Step Guidance That Needs Progress
+
+Step-by-step answers are another place where text looks organized but behaves
+poorly.
+
+Consider a setup assistant for configuring an analytics integration:
+
+```text
+1. Create an API key.
+2. Add the tracking script.
+3. Configure allowed domains.
+4. Send a test event.
+5. Verify the event in the dashboard.
+```
+
+The list is clear, but it has no memory. It cannot show which steps are done,
+which ones failed, which one is blocked by permissions, or where the user should
+resume tomorrow.
+
+The useful version is a progress workspace:
+
+- A stepper with current state.
+- A checklist for prerequisites.
+- Inline code snippets for the selected framework.
+- Status cards for tests that passed or failed.
+- A retry action for the test event.
+- A final verification panel.
+
+The assistant can still explain what each step means, but the workflow state
+belongs on screen. If the user completes step two, the interface should change.
+If step four fails, the error should attach to step four, not appear as a new
+paragraph below the list.
+
+This is especially important for AI agents because they often operate across
+time. A text transcript is a weak project memory. A generated stepper or task
+board gives the user a stable place to re-enter the workflow.
+
+OpenUI fits this pattern because the app can expose workflow components with
+strict states such as `pending`, `active`, `blocked`, and `complete`. The model
+can arrange the workflow for the current context, but state transitions remain
+application-owned. The UI can be generated without making the workflow logic
+uncontrolled.
+
+## 5. Risk Reviews That Need Explicit Actions
+
+Risk is easy to understate in prose.
+
+An assistant reviewing a pull request, contract, migration, or launch plan might
+produce a strong written summary:
+
+```text
+The main risk is that the migration changes the billing table before the
+backfill job has verified row counts. I recommend running a dry run, comparing
+counts, and adding a rollback plan.
+```
+
+That is useful advice. It is not yet an operational review surface. The user
+still needs to separate blockers from warnings, assign owners, mark evidence,
+and decide what must happen before approval.
+
+A better generated UI would show:
+
+- A risk matrix grouped by severity.
+- Evidence links for each finding.
+- Required checks before approval.
+- Owner fields.
+- A decision panel with approve, hold, or request changes.
+- A short explanation of what each action will do.
+
+This turns the answer into a controlled review. The assistant is not merely
+persuasive; it is accountable to the structure of the decision.
+
+The key is that actions must be explicit. A model-generated risk panel should
+not silently approve a launch or merge a PR. It should prepare the surface where
+a human can review the evidence and choose an action the application supports.
+
+This is one of the strongest cases for generative UI in internal tools. Many
+business workflows are not missing information; they are missing a temporary,
+context-specific interface for reviewing that information. Plain text makes the
+reviewer do the interface work mentally. OpenUI can let the model assemble the
+review surface from safe components the application already trusts.
+
+## What Changes for Developers
+
+The mental model shift is small but important:
+
+- Do not ask the model to generate your app.
+- Give the model a vocabulary of approved interface pieces.
+- Let it choose the right surface for the task.
+- Validate every prop and every action.
+- Keep business logic outside the generated output.
+
+The result is not a free-form UI generator. It is a renderer for structured
+answers. That is a much more useful and safer thing to build.
+
+Plain text should remain the default for explanation, narrative, and
+conversation. But when the answer contains rows, choices, fields, steps, status,
+or actions, text is usually a downgrade. The user is not just reading anymore.
+They are comparing, sorting, filling, checking, and deciding.
+
+Those tasks deserve a workspace.


### PR DESCRIPTION
/claim #5

## Summary

Adds a written article for issue #5: "5 Things That Look Terrible as Plain Text (And How OpenUI Fixes Them)."

Article added:
- `Articles/Five AI Answers That Should Be Workspaces Not Paragraphs.md`

Angle:
- Frames the five examples as AI answers that should become small, task-specific workspaces rather than static paragraphs.
- Covers comparison inspection, sortable data summaries, validated forms, progress-aware setup guidance, and explicit risk review actions.
- Keeps OpenUI positioned as a constrained renderer/component-vocabulary layer, not a free-form UI generator.
- Emphasizes application-owned validation, permissions, state transitions, and action handlers.

## Validation

- `git diff --check`
- `git diff --cached --check` before commit
- Word count: 1,716 words
- No project code, package install, build, test, or untrusted executable code was run

## Disclosure

AI-assisted drafting/editing was used, with human review for structure, specificity, and fit to the issue brief.