### PR TITLE
Add article on AI answers as workspaces

### DIFF
--- a/Articles/Five AI Answers That Should Be Workspaces.md
+++ b/Articles/Five AI Answers That Should Be Workspaces.md
@@ -1,0 +1,183 @@
+# Five AI Answers That Should Be Workspaces
+
+Text is a great format for explanation. It is a poor format for work.
+
+That distinction matters more as AI assistants move from answering questions to helping users finish tasks. A paragraph can summarize a deployment plan. A bullet list can describe an incident. A markdown table can compare vendors. But once the user needs to inspect, edit, approve, filter, retry, or take action, text starts to collapse under the weight of the workflow.
+
+This is the gap OpenUI is trying to close. Instead of treating model output as a final text blob, OpenUI lets a model describe structured UI from a component library your app controls. The answer can become a surface: tables, cards, forms, checklists, charts, and actions that still belong to your product.
+
+Here are five common AI answers that should usually be workspaces instead of plain text.
+
+## 1. Product comparisons
+
+Plain text version:
+
+```txt
+Option A is cheaper and easier to integrate. Option B has better reporting.
+Option C has the strongest enterprise controls but takes longer to deploy.
+```
+
+That is fine for a quick take. It is not enough when the user is actually choosing.
+
+A comparison is a structured decision. People need to scan criteria, sort tradeoffs, expand details, remove weak options, and sometimes change the weights. Text turns that into a memory exercise. The reader has to keep every criterion in their head and manually compare sentences across paragraphs.
+
+A generated workspace can render the answer as:
+
+- a comparison table with consistent criteria,
+- tags for risk and fit,
+- a scorecard that exposes assumptions,
+- a notes column for evidence,
+- and action buttons for "shortlist", "ask follow-up", or "export".
+
+The value is not that the table looks nicer. The value is that the decision becomes inspectable.
+
+With OpenUI, this kind of response should be built from approved components, not raw HTML invented by the model. The model can output something like a `ComparisonTable`, `TradeoffCard`, and `DecisionActions`. The app decides how those render, which actions are allowed, and what data each action needs.
+
+## 2. Incident triage
+
+Plain text version:
+
+```txt
+The checkout failure is likely caused by the payment service timeout.
+Priority is high. Check the gateway logs and consider rollback if error
+rates stay elevated.
+```
+
+That paragraph loses the operational shape of the problem.
+
+Incident responders need state. Which signals are confirmed? Which are guesses? What changed recently? Who owns the next action? Which mitigation is reversible? What is the current customer impact? Text can describe all of that, but it does not keep it organized under pressure.
+
+A useful incident workspace can show:
+
+- severity and confidence as visible badges,
+- a timeline of known events,
+- current hypotheses with evidence links,
+- active mitigations and owners,
+- rollback criteria,
+- and a post-incident follow-up checklist.
+
+When this appears as UI, the team can work from it. They can mark a hypothesis as disproven, assign the next check, or click into the log query that supports a claim.
+
+OpenUI's streaming model is especially useful here. The assistant can render the severity and summary first, then fill in timeline and action sections as more context streams in. The user does not need to wait for the perfect final answer before getting a useful response.
+
+## 3. Forms and data collection
+
+Plain text version:
+
+```txt
+To open a vendor request, provide the vendor name, contract value,
+security contact, data types, and desired launch date.
+```
+
+The assistant has correctly identified the fields, but the user still has to do the work somewhere else.
+
+Forms are one of the clearest places where text output is the wrong endpoint. If an AI knows the fields it needs, it should render a form with labels, validation, defaults, help text, and a submit action. The model should not decide how submission works. It should describe the form state the application is prepared to collect.
+
+A workspace version can provide:
+
+- required and optional fields,
+- validation hints,
+- a summary preview,
+- missing-field warnings,
+- save-as-draft,
+- and a final submit button controlled by the app.
+
+This is also where a component contract matters. The model should not generate arbitrary form markup. It should choose from components like `RequestForm`, `FormControl`, `TextInput`, `DateInput`, and `SubmitActions`. Your app handles validation and persistence.
+
+That makes the generated surface useful without making it unsafe.
+
+## 4. Setup or migration guidance
+
+Plain text version:
+
+```txt
+Step 1: install dependencies. Step 2: configure environment variables.
+Step 3: run migrations. Step 4: deploy. Step 5: verify logs.
+```
+
+This looks helpful until something goes wrong.
+
+Setup tasks are state machines. A user needs to know what is done, what is blocked, what command to run, what output to expect, and what recovery path applies when a step fails. A list of instructions does not preserve that state.
+
+A generated workspace can turn setup guidance into:
+
+- a checklist with status per step,
+- command blocks with expected output,
+- inline troubleshooting cards,
+- environment-variable validation,
+- copy buttons,
+- and a "continue from here" action after the user reports success or failure.
+
+This is not just a documentation upgrade. It reduces context switching. The assistant can keep the user's place in the workflow and make the next step visible.
+
+OpenUI helps by letting the model render a controlled setup surface instead of a wall of markdown. If a step needs a command, it can use a `CommandStep`. If a step is risky, it can use a `WarningCallout`. If the user needs to choose a branch, it can use a `ChoiceGroup`. The application still owns execution.
+
+## 5. Risk review and approvals
+
+Plain text version:
+
+```txt
+This change looks safe overall, but there is some risk around permissions
+and data retention. I recommend approving after legal review.
+```
+
+That answer is too soft for an approval workflow.
+
+Approvals need explicit boundaries. What exactly is being approved? Which risks are accepted? Which checks passed? Which checks failed? Who can approve? Is there a required second reviewer? What happens after approval?
+
+A generated approval workspace can include:
+
+- a decision summary,
+- risk items grouped by severity,
+- evidence for each recommendation,
+- missing prerequisites,
+- approve and decline actions,
+- and a required confirmation note for irreversible changes.
+
+This is where generated UI can improve safety. Text nudges. UI can force explicit decisions.
+
+The important rule is that the UI should never give the model authority it does not have. The model can recommend and structure the review. The app must enforce permissions, record the decision, and execute the action.
+
+## The pattern behind all five examples
+
+These examples look different, but they share the same failure mode. Plain text loses the working structure.
+
+A comparison loses columns and weights. An incident loses state. A form loses validation. A setup guide loses progress. An approval loses decision boundaries.
+
+Generative UI is useful when the answer has shape:
+
+- repeated rows,
+- visible state,
+- user input,
+- branching actions,
+- validation rules,
+- live data,
+- or a decision that must be recorded.
+
+When the answer is only a concept, text is enough. When the answer is a task surface, text is just the transcript.
+
+## Why OpenUI is a good boundary
+
+The dangerous version of generative UI is "let the model make a screen". That gives too much power to an output source that can be inconsistent.
+
+The practical version is "let the model choose from a product-approved component library".
+
+OpenUI follows that second pattern. You define components, schemas, descriptions, and a root. The model outputs OpenUI Lang constrained by that library. The renderer maps the parsed output to real React components. Actions flow back through callbacks your app controls.
+
+That means the assistant can create the right surface for the task without inventing the whole frontend.
+
+For the five examples above, the model should not output arbitrary UI. It should output a `ComparisonTable`, `IncidentReview`, `RequestForm`, `SetupChecklist`, or `ApprovalPanel` that your app already knows how to render safely.
+
+## A simple test for product teams
+
+When deciding whether an AI answer should stay as text or become UI, ask three questions:
+
+1. Will the user need to compare multiple structured items?
+2. Will the user need to edit, validate, approve, or execute something?
+3. Will the user return to this answer as a workspace rather than just read it once?
+
+If the answer is yes, text is probably the wrong final format.
+
+The future of AI interfaces is not that every answer becomes a giant dashboard. Most answers should still be concise. But when an answer represents work, the assistant should give the user a surface to work on.
+
+That is the shift OpenUI makes possible: from generated text as the endpoint to generated UI as the starting point for action.


### PR DESCRIPTION
﻿## Summary
- adds an issue #5 article using a distinct "AI answers that should become workspaces" angle
- covers five concrete cases where plain text loses useful working structure: product comparisons, incident triage, forms, setup guidance, and approval reviews
- positions OpenUI as the constrained component-library boundary for turning those answers into safe rendered surfaces

## Validation
- `git diff --check`
- `npx --yes markdownlint-cli "Articles/Five AI Answers That Should Be Workspaces.md" --disable MD013`

## Disclosure
Drafting and editing were AI-assisted. I checked the article against the OpenUI component-library and renderer model, and I am responsible for the final wording and technical accuracy.

Related: #5
